### PR TITLE
Ensure asset directory symlink is an absolute path

### DIFF
--- a/R/assets.R
+++ b/R/assets.R
@@ -153,6 +153,10 @@ assets_install_link <- function(
   install_local_helper(
     ...,
     install_fn = function(from, to) {
+      # Make sure from is an absolute path
+      if (!fs::is_absolute_path(from)) {
+        from <- fs::path_wd(from)
+      }
       # Make sure parent folder exists
       fs::dir_create(fs::path_dir(to))
       # Link dir


### PR DESCRIPTION
Consider the use of `assets_install_link()` with a relative path:

```
> shinylive::assets_install_link('../shinylive')
```

The created symbolic link is then relative,

```
$ ls -l /Users/georgestagg/Library/Caches/shinylive/
total 0
lrwxr-xr-x  1 georgestagg  staff  18 13 Sep 10:05 shinylive-0.2.0 -> ../shinylive/build
```

But I would expect it to create a symbolic link with an absolute path, formed relative to the working directory at the time of running `assets_install_link()`.

This PR does that.