### PR TITLE
Set wasm engine when templating for Shinylive

### DIFF
--- a/R/app_json.R
+++ b/R/app_json.R
@@ -196,6 +196,14 @@ write_app_json <- function(
       fixed = TRUE
     )
 
+    # Set wasm engine
+    index_content <- gsub(
+      pattern = "{{APP_ENGINE}}",
+      replacement = "r",
+      index_content,
+      fixed = TRUE
+    )
+
     # Save updated file contents
     brio::write_file(index_content, copy_info$dest)
   }


### PR DESCRIPTION
See https://github.com/posit-dev/shinylive/pull/64 for details.