### PR TITLE
Increasing download timeout

### DIFF
--- a/R/assets.R
+++ b/R/assets.R
@@ -36,6 +36,11 @@ assets_download <- function(
   )
 
   message("Downloading shinylive assets v", version, "...")
+
+  # temporarily increase download timeout for ?utils::download.file guidelines
+  opts <- options(timeout = 250 * 60 * 2)  # expect minimum 0.5 MB/s
+  on.exit(options(opts))
+
   utils::download.file(url, destfile = tmp_targz, method = "auto")
 
   message("Unzipping to ", dir, "/")


### PR DESCRIPTION
My quarto presentations error with a `utils::download.file` timeout (defaults to 60s, expecting ~4MB/s for the 250MB `shinylive` archive). Not sure if it's limited by my internet or the github release artifacts server throttling downloads, but regardless this exceeds the guidelines in `?utils::download.file`:

> It is unrealistic to require download times of less than 1s/MB.

Just temporarily bumping the download timeout to accommodate the file size. Not sure how much you want to engineer this, but this could even catch the error and check to see if it failed due to a timeout, and if so suggest rerunning with `R_DEFAULT_INTERNET_TIMEOUT` increased.