### PR TITLE
feat: Use `{httr2}` to download assets to avoid timeout and give a progress bar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     archive,
     brio,
     fs,
+    httr2 (>= 1.0.0),
     jsonlite,
     progress,
     rappdirs,
@@ -27,7 +28,6 @@ Imports:
     tools
 Suggests:
     plumber,
-    httr,
     spelling,
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinylive (development version)
 
+* Use `{httr2}` to download assets from GitHub releases. (@dgkf #30, #39)
+
 # shinylive 0.1.0
 
 * Initial CRAN submission.

--- a/R/assets.R
+++ b/R/assets.R
@@ -374,6 +374,8 @@ assets_version <- function() {
 check_assets_url <- function(
     version = assets_version(),
     url = assets_bundle_url(version)) {
-  req <- httr::HEAD(url)
-  req$status_code == 200
+  req <- httr2::request(url)
+  req <- httr2::req_method(req, "HEAD")
+  resp <- httr2::req_perform(req)
+  resp$status_code == 200
 }

--- a/R/assets.R
+++ b/R/assets.R
@@ -21,10 +21,14 @@ assets_download <- function(
     version = assets_version(),
     ...,
     # Note that this is the cache directory, which is the parent of the assets
-    # directory. The tarball will have the assets directory as the top-level subdir.
+    # directory. The tarball will have the assets directory as the top-level
+    # subdir.
     dir = assets_cache_dir(),
     url = assets_bundle_url(version)) {
-  tmp_targz <- tempfile(paste0("shinylive-", gsub(".", "_", version, fixed = TRUE), "-"), fileext = ".tar.gz")
+  tmp_targz <- tempfile(
+    paste0("shinylive-", gsub(".", "_", version, fixed = TRUE), "-"),
+    fileext = ".tar.gz"
+  )
 
   on.exit(
     {
@@ -36,12 +40,10 @@ assets_download <- function(
   )
 
   message("Downloading shinylive assets v", version, "...")
-
-  # temporarily increase download timeout for ?utils::download.file guidelines
-  opts <- options(timeout = 250 * 60 * 2)  # expect minimum 0.5 MB/s
-  on.exit(options(opts))
-
-  utils::download.file(url, destfile = tmp_targz, method = "auto")
+  req <- httr2::request(url)
+  req <- httr2::req_progress(req)
+  httr2::req_perform(req, path = tmp_targz)
+  message("") # Newline after progress bar
 
   message("Unzipping to ", dir, "/")
   fs::dir_create(dir)


### PR DESCRIPTION
Related to #30 