### PR TITLE
Export R shinylive apps with Wasm package binaries included in static assets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: Exporting 'shiny' applications with 'shinylive' allows you to run t
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 BugReports: https://github.com/posit-dev/r-shinylive/issues
 URL: https://posit-dev.github.io/r-shinylive/, https://github.com/posit-dev/r-shinylive
 Imports:
@@ -22,6 +22,7 @@ Imports:
     brio,
     fs,
     glue,
+    gh,
     httr2 (>= 1.0.0),
     jsonlite,
     pkgdepends,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,12 +18,16 @@ BugReports: https://github.com/posit-dev/r-shinylive/issues
 URL: https://posit-dev.github.io/r-shinylive/, https://github.com/posit-dev/r-shinylive
 Imports:
     archive,
+    base64enc,
     brio,
     fs,
+    glue,
     httr2 (>= 1.0.0),
     jsonlite,
+    pkgdepends,
     progress,
     rappdirs,
+    renv,
     rlang,
     tools
 Suggests:

--- a/R/export.R
+++ b/R/export.R
@@ -78,8 +78,8 @@ export <- function(
     p <- progress::progress_bar$new(
       format = "[:bar] :percent\n",
       total = length(base_files),
-      clear = TRUE,
-      # show_after = 0
+      clear = FALSE,
+      show_after = 0
     )
   }
   Map(

--- a/R/export.R
+++ b/R/export.R
@@ -8,6 +8,10 @@
 #' @param subdir Subdirectory of `destdir` to write the app to.
 #' @param verbose Print verbose output. Defaults to `TRUE` if running
 #'    interactively.
+#' @param wasm_packages Download and include binary WebAssembly packages as
+#'    part of the output app's static assets. Defaults to `TRUE`.
+#' @param package_cache Cache downloaded binary WebAssembly packages. Defaults
+#'    to `TRUE`.
 #' @param ... Ignored
 #' @export
 #' @return Nothing. The app is exported to `destdir`. Instructions for serving
@@ -29,7 +33,9 @@ export <- function(
     destdir,
     ...,
     subdir = "",
-    verbose = is_interactive()) {
+    verbose = is_interactive(),
+    wasm_packages = TRUE,
+    package_cache = TRUE) {
   verbose_print <- if (verbose) message else list
 
   stopifnot(fs::is_dir(appdir))
@@ -70,7 +76,7 @@ export <- function(
   base_files <- c(shinylive_common_files("base"), shinylive_common_files("r"))
   if (verbose) {
     p <- progress::progress_bar$new(
-      format = "[:bar] :percent",
+      format = "[:bar] :percent\n",
       total = length(base_files),
       clear = TRUE,
       # show_after = 0
@@ -138,6 +144,13 @@ export <- function(
   #         os.makedirs(dest_path.parent)
 
   #     copy_fn(src_path, dest_path)
+
+  # =========================================================================
+  # Copy app package dependencies as Wasm binaries
+  # =========================================================================
+  if (wasm_packages) {
+    download_wasm_packages(appdir, destdir, verbose, package_cache)
+  }
 
   # =========================================================================
   # For each app, write the index.html, edit/index.html, and app.json in

--- a/R/packages.R
+++ b/R/packages.R
@@ -141,7 +141,7 @@ get_github_wasm_assets <- function(desc) {
 
 # Lookup URL and metadata for Wasm binary package
 prepare_wasm_metadata <- function(pkg, metadata, verbose) {
-  desc <- packageDescription(pkg)
+  desc <- utils::packageDescription(pkg)
   repo <- desc$Repository
   prev_ref <- metadata$ref
   prev_cached <- metadata$cached
@@ -253,7 +253,7 @@ download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
     if (!meta$cached) {
       # Download Wasm binaries and copy to static assets dir
       for (file in meta$assets) {
-        download.file(file$url, fs::path(pkg_subdir, file$filename))
+        utils::download.file(file$url, fs::path(pkg_subdir, file$filename))
       }
       meta$cached <- TRUE
       meta$path <- glue::glue("packages/{pkg}/{meta$assets[[1]]$filename}")

--- a/R/packages.R
+++ b/R/packages.R
@@ -1,8 +1,8 @@
 # Resolve package list hard dependencies
 resolve_dependencies <- function(pkgs, verbose) {
   pkg_refs <- find.package(pkgs, lib.loc = NULL, quiet = FALSE, verbose)
-  pkg_refs <- glue::glue("installed::{pkg_refs}")
-  inst <- pkgdepends::new_pkg_installation_proposal(pkg_refs)
+  pkg_refs <- glue::glue("local::{pkg_refs}")
+  inst <- pkgdepends::new_pkg_deps(pkg_refs)
   inst$resolve()
   unique(inst$get_resolution()$package)
 }

--- a/R/packages.R
+++ b/R/packages.R
@@ -211,16 +211,14 @@ download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
     p <- progress::progress_bar$new(
       format = "[:bar] :percent\n",
       total = length(pkgs),
-      clear = TRUE
+      clear = TRUE,
+      show_after = 0
     )
   }
 
   # Create empty R packages directory in app assets if not already there
   pkg_dir <- fs::path(destdir, "shinylive", "webr", "packages")
-  if (!fs::dir_exists(pkg_dir)) {
-    verbose_print("Creating ", pkg_dir, "/")
-    fs::dir_create(pkg_dir)
-  }
+  fs::dir_create(pkg_dir, recurse = TRUE)
 
   verbose_print(
     "Downloading WebAssembly R package binaries to ", pkg_dir, "/"
@@ -240,9 +238,7 @@ download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
     if (verbose) p$tick()
 
     pkg_subdir <- fs::path(pkg_dir, pkg)
-    if (!fs::dir_exists(pkg_subdir)) {
-      fs::dir_create(pkg_subdir)
-    }
+    fs::dir_create(pkg_subdir, recurse = TRUE)
 
     prev_meta <- if (pkg %in% names(prev_metadata)) {
       prev_metadata[[pkg]]

--- a/R/packages.R
+++ b/R/packages.R
@@ -234,7 +234,7 @@ download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
 
   # Loop over packages and download them if not cached
   names(pkgs) <- pkgs
-  cur_metadata <- sapply(pkgs, function(pkg) {
+  cur_metadata <- lapply(pkgs, function(pkg) {
     if (verbose) p$tick()
 
     pkg_subdir <- fs::path(pkg_dir, pkg)
@@ -257,15 +257,14 @@ download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
       meta$path <- glue::glue("packages/{pkg}/{meta$assets[[1]]$filename}")
     }
     meta
-  }, simplify = FALSE, USE.NAMES = TRUE)
+  })
 
   # Merge metadata to protect previous cache
   pkgs <- unique(c(names(prev_metadata), names(cur_metadata)))
-  metadata <- mapply(
+  metadata <- Map(
     function(a, b) if (is.null(b)) a else b,
     prev_metadata[pkgs],
-    cur_metadata[pkgs],
-    SIMPLIFY = FALSE, USE.NAMES = FALSE
+    cur_metadata[pkgs]
   )
   names(metadata) <- pkgs
 

--- a/R/packages.R
+++ b/R/packages.R
@@ -16,12 +16,13 @@ get_default_wasm_assets <- function(desc) {
   contrib <- glue::glue("{r_wasm}/bin/emscripten/contrib/{r_short}")
 
   info <- utils::available.packages(contriburl = contrib)
-  ver <- info[pkg, "Version", drop = TRUE]
   if (!pkg %in% rownames(info)) {
-    rlang::abort(c(
-      glue::glue("Can't find \"{pkg}\" in r-universe binary repository.")
+    rlang::warn(c(
+      glue::glue("Can't find \"{pkg}\" in webR binary repository.")
     ))
+    return(list())
   }
+  ver <- info[pkg, "Version", drop = TRUE]
 
   # Show a warning if packages major.minor versions differ
   # We don't worry too much about patch, since webR versions of packages may be
@@ -55,12 +56,13 @@ get_r_universe_wasm_assets <- function(desc) {
   contrib <- glue::glue("{r_universe}/bin/emscripten/contrib/{r_short}")
 
   info <- utils::available.packages(contriburl = contrib)
-  ver <- info[pkg, "Version", drop = TRUE]
   if (!pkg %in% rownames(info)) {
-    rlang::abort(c(
+    rlang::warn(c(
       glue::glue("Can't find \"{pkg}\" in r-universe binary repository.")
     ))
+    return(list())
   }
+  ver <- info[pkg, "Version", drop = TRUE]
 
   # Show a warning if packages major.minor versions differ
   # We don't worry too much about patch, since webR versions of packages may be
@@ -250,7 +252,7 @@ download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
     # Create package ref and lookup download URLs
     meta <- prepare_wasm_metadata(pkg, prev_meta, verbose)
 
-    if (!meta$cached) {
+    if (!meta$cached && length(meta$assets) > 0) {
       # Download Wasm binaries and copy to static assets dir
       for (file in meta$assets) {
         utils::download.file(file$url, fs::path(pkg_subdir, file$filename))

--- a/R/packages.R
+++ b/R/packages.R
@@ -1,0 +1,280 @@
+# Resolve package list hard dependencies
+resolve_dependencies <- function(pkgs, verbose) {
+  pkg_refs <- find.package(pkgs, lib.loc = NULL, quiet = FALSE, verbose)
+  pkg_refs <- glue::glue("installed::{pkg_refs}")
+  inst <- pkgdepends::new_pkg_installation_proposal(pkg_refs)
+  inst$resolve()
+  unique(inst$get_resolution()$package)
+}
+
+get_default_wasm_assets <- function(desc) {
+  pkg <- desc$Package
+  r_wasm <- "http://repo.r-wasm.org"
+  # TODO: Restore the use of short version, once webR with R 4.4.0 is released.
+  #       This function can then be merged with `get_r_universe_wasm_assets()`
+  r_short <- WEBR_R_VERSION
+  contrib <- glue::glue("{r_wasm}/bin/emscripten/contrib/{r_short}")
+
+  info <- utils::available.packages(contriburl = contrib)
+  ver <- info[pkg, "Version", drop = TRUE]
+  if (!pkg %in% rownames(info)) {
+    rlang::abort(c(
+      glue::glue("Can't find \"{pkg}\" in r-universe binary repository.")
+    ))
+  }
+
+  # Show a warning if packages major.minor versions differ
+  # We don't worry too much about patch, since webR versions of packages may be
+  # patched at the repo for compatibility with Emscripten
+  inst_ver <- package_version(desc$Version)
+  repo_ver <- package_version(ver)
+  if (inst_ver$major != repo_ver$major || inst_ver$minor != repo_ver$minor) {
+    rlang::warn(c(
+      glue::glue("Package version mismatch for \"{pkg}\", ensure the versions below are compatible."),
+      "!" = glue::glue("Installed version: {desc$Version}, WebAssembly version: {ver}."),
+      "i" = "Install a package version matching the WebAssembly version to silence this error."
+    ))
+  }
+
+  list(
+    list(
+      filename = glue::glue("{pkg}_{ver}.data"),
+      url = glue::glue("{contrib}/{pkg}_{ver}.data")
+    ),
+    list(
+      filename = glue::glue("{pkg}_{ver}.js.metadata"),
+      url = glue::glue("{contrib}/{pkg}_{ver}.js.metadata")
+    )
+  )
+}
+
+get_r_universe_wasm_assets <- function(desc) {
+  pkg <- desc$Package
+  r_universe <- desc$Repository
+  r_short <- gsub("\\.[^.]+$", "", WEBR_R_VERSION)
+  contrib <- glue::glue("{r_universe}/bin/emscripten/contrib/{r_short}")
+
+  info <- utils::available.packages(contriburl = contrib)
+  ver <- info[pkg, "Version", drop = TRUE]
+  if (!pkg %in% rownames(info)) {
+    rlang::abort(c(
+      glue::glue("Can't find \"{pkg}\" in r-universe binary repository.")
+    ))
+  }
+
+  # Show a warning if packages major.minor versions differ
+  # We don't worry too much about patch, since webR versions of packages may be
+  # patched at the repo for compatibility with Emscripten
+  inst_ver <- package_version(desc$Version)
+  repo_ver <- package_version(ver)
+  if (inst_ver$major != repo_ver$major || inst_ver$minor != repo_ver$minor) {
+    rlang::warn(c(
+      glue::glue("Package version mismatch for \"{pkg}\", ensure the versions below are compatible."),
+      "!" = glue::glue("Installed version: {desc$Version}, WebAssembly version: {ver}."),
+      "i" = "Install a package version matching the WebAssembly version to silence this error."
+    ))
+  }
+
+  list(
+    list(
+      filename = glue::glue("{pkg}_{ver}.data"),
+      url = glue::glue("{contrib}/{pkg}_{ver}.data")
+    ),
+    list(
+      filename = glue::glue("{pkg}_{ver}.js.metadata"),
+      url = glue::glue("{contrib}/{pkg}_{ver}.js.metadata")
+    )
+  )
+}
+
+get_github_wasm_assets <- function(desc) {
+  pkg <- desc$Package
+  user <- desc$RemoteUsername
+  repo <- desc$RemoteRepo
+  ref <- desc$RemoteRef
+
+  # Find a release for installed package's RemoteRef
+  tags <- tryCatch(
+    gh::gh("/repos/{user}/{repo}/releases/tags/{ref}",
+      user = user, repo = repo, ref = ref
+    ),
+    error = function(err) {
+      rlang::abort(c(
+        glue::glue("Can't find GitHub release for github::{user}/{repo}@{ref}"),
+        "!" = glue::glue("Ensure a GitHub release exists for the package repository reference: \"{ref}\"."),
+        "i" = "Alternatively, install a CRAN version of this package to use the default Wasm binary repository."
+      ), parent = err)
+    }
+  )
+
+  # Find GH release asset URLs for R library VFS image
+  library_data <- Filter(function(item) {
+    item$name == "library.data"
+  }, tags$assets)
+  library_metadata <- Filter(function(item) {
+    item$name == "library.js.metadata"
+  }, tags$assets)
+
+  if (length(library_data) == 0 || length(library_metadata) == 0) {
+    # We are stricter here than with CRAN-like repositories, the asset bundle
+    # `RemoteRef` must match exactly. This allows for the use of development
+    # versions of packages through the GitHub pre-releases feature.
+    rlang::abort(c(
+      glue::glue("Can't find WebAssembly binary assets for github::{user}/{repo}@{ref}"),
+      "!" = glue::glue("Ensure WebAssembly binary assets are associated with the GitHub release \"{ref}\"."),
+      "i" = "WebAssembly binary assets can be built on release using GitHub Actions: https://github.com/r-wasm/actions",
+      "i" = "Alternatively, install a CRAN version of this package to use the default Wasm binary repository."
+    ))
+  }
+
+  list(
+    list(
+      filename = library_data[[1]]$name,
+      url = library_data[[1]]$browser_download_url
+    ),
+    list(
+      filename = library_metadata[[1]]$name,
+      url = library_metadata[[1]]$browser_download_url
+    )
+  )
+}
+
+# Lookup URL and metadata for Wasm binary package
+prepare_wasm_metadata <- function(pkg, metadata, verbose) {
+  desc <- packageDescription(pkg)
+  repo <- desc$Repository
+  prev_ref <- metadata$ref
+  prev_cached <- metadata$cached
+  metadata$name <- pkg
+  metadata$version <- desc$Version
+
+  # Skip base R packages
+  if (!is.null(desc$Priority) && desc$Priority == "base") {
+    metadata$ref <- glue::glue("{metadata$name}@{metadata$version}")
+    metadata$type <- "base"
+    metadata$cached <- prev_cached <- TRUE
+    if (verbose) {
+      message("Skipping base R package: ", metadata$ref)
+    }
+    return(metadata)
+  }
+
+  # Set a package ref for caching
+  if (!is.null(desc$RemoteType) && desc$RemoteType == "github") {
+    user <- desc$RemoteUsername
+    repo <- desc$RemoteRepo
+    sha <- desc$RemoteSha
+    metadata$ref <- glue::glue("github::{user}/{repo}@{sha}")
+  } else if (repo == "CRAN") {
+    metadata$ref <- glue::glue("{metadata$name}@{metadata$version}")
+  } else if (grepl("Bioconductor", repo)) {
+    metadata$ref <- glue::glue("bioc::{metadata$name}@{metadata$version}")
+  } else if (grepl("r-universe\\.dev$", repo)) {
+    metadata$ref <- glue::glue("{repo}::{metadata$name}@{desc$RemoteSha}")
+  } else {
+    metadata$ref <- glue::glue("{metadata$name}@{metadata$version}")
+  }
+
+  # If not cached, discover Wasm binary URLs
+  if (is.null(prev_cached) || !prev_cached || prev_ref != metadata$ref) {
+    metadata$cached <- FALSE
+    if (!is.null(desc$RemoteType) && desc$RemoteType == "github") {
+      metadata$assets <- get_github_wasm_assets(desc)
+      metadata$type <- "library"
+    } else if (grepl("r-universe\\.dev$", repo)) {
+      metadata$assets <- get_r_universe_wasm_assets(desc)
+      metadata$type <- "package"
+    } else {
+      # Fallback to repo.r-wasm.org lookup for CRAN and anything else
+      metadata$assets <- get_default_wasm_assets(desc)
+      metadata$type <- "package"
+    }
+  } else if (verbose) {
+    message("Skipping cached Wasm binary: ", metadata$ref)
+  }
+
+  metadata
+}
+
+download_wasm_packages <- function(appdir, destdir, verbose, package_cache) {
+  verbose_print <- if (verbose) message else list
+  # App dependencies, ignoring shiny packages in base webR image
+  pkgs <- unique(renv::dependencies(appdir, quiet = !verbose)$Package)
+  pkgs <- pkgs[pkgs != "shiny" & pkgs != "bslib"]
+  if (length(pkgs) > 0) {
+    pkgs <- resolve_dependencies(pkgs, verbose)
+  }
+
+  if (verbose) {
+    p <- progress::progress_bar$new(
+      format = "[:bar] :percent\n",
+      total = length(pkgs),
+      clear = TRUE
+    )
+  }
+
+  # Create empty R packages directory in app assets if not already there
+  pkg_dir <- fs::path(destdir, "shinylive", "webr", "packages")
+  if (!fs::dir_exists(pkg_dir)) {
+    verbose_print("Creating ", pkg_dir, "/")
+    fs::dir_create(pkg_dir)
+  }
+
+  verbose_print(
+    "Downloading WebAssembly R package binaries to ", pkg_dir, "/"
+  )
+
+  # Load existing metadata from disk, from a previously deployed app
+  metadata_file <- fs::path(destdir, "shinylive", "webr", "packages", "metadata.rds")
+  prev_metadata <- if (package_cache && fs::file_exists(metadata_file)) {
+    readRDS(metadata_file)
+  } else {
+    list()
+  }
+
+  # Loop over packages and download them if not cached
+  names(pkgs) <- pkgs
+  cur_metadata <- sapply(pkgs, function(pkg) {
+    if (verbose) p$tick()
+
+    pkg_subdir <- fs::path(pkg_dir, pkg)
+    if (!fs::dir_exists(pkg_subdir)) {
+      fs::dir_create(pkg_subdir)
+    }
+
+    prev_meta <- if (pkg %in% names(prev_metadata)) {
+      prev_metadata[[pkg]]
+    } else {
+      list()
+    }
+    # Create package ref and lookup download URLs
+    meta <- prepare_wasm_metadata(pkg, prev_meta, verbose)
+
+    if (!meta$cached) {
+      # Download Wasm binaries and copy to static assets dir
+      for (file in meta$assets) {
+        download.file(file$url, fs::path(pkg_subdir, file$filename))
+      }
+      meta$cached <- TRUE
+      meta$path <- glue::glue("packages/{pkg}/{meta$assets[[1]]$filename}")
+    }
+    meta
+  }, simplify = FALSE, USE.NAMES = TRUE)
+
+  # Merge metadata to protect previous cache
+  pkgs <- unique(c(names(prev_metadata), names(cur_metadata)))
+  metadata <- mapply(
+    function(a, b) if (is.null(b)) a else b,
+    prev_metadata[pkgs],
+    cur_metadata[pkgs],
+    SIMPLIFY = FALSE, USE.NAMES = FALSE
+  )
+  names(metadata) <- pkgs
+
+  # Remove base packages from caching and metadata
+  metadata <- Filter(function(item) item$type != "base", metadata)
+
+  verbose_print("Writing app metadata to ", metadata_file, appendLF = FALSE)
+  saveRDS(metadata, metadata_file)
+  verbose_print(": ", fs::file_info(metadata_file)$size[1], " bytes")
+}

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -5,6 +5,7 @@
 #' @param args Command line arguments passed by the extension. See details for more information.
 #' @param ... Ignored.
 #' @param pretty Whether to pretty print the JSON output.
+#' @param con File from which to take input. Default: `"stdin"`.
 #' @return Nothing. Values are printed to stdout.
 #' @section Command arguments:
 #'
@@ -112,7 +113,9 @@
 quarto_ext <- function(
     args = commandArgs(trailingOnly = TRUE),
     ...,
-    pretty = is_interactive()) {
+    pretty = is_interactive(),
+    con = "stdin"
+  ) {
   stopifnot(length(list(...)) == 0)
   # This method should not print anything to stdout. Instead, it should return a JSON string that will be printed by the extension.
   stopifnot(length(args) >= 1)
@@ -204,7 +207,7 @@ quarto_ext <- function(
       # shinylive_python_resources()
     },
     "app-resources" = {
-      app_json <- readLines("stdin", warn = FALSE)
+      app_json <- readLines(con, warn = FALSE)
       build_app_resources(app_json)
     },
     {

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -204,7 +204,8 @@ quarto_ext <- function(
       # shinylive_python_resources()
     },
     "app-resources" = {
-      list()
+      app_json <- readLines("stdin", warn = FALSE)
+      build_app_resources(app_json)
     },
     {
       stop("Not implemented `extension` type: ", args[2])
@@ -220,6 +221,53 @@ quarto_ext <- function(
   invisible()
 }
 
+build_app_resources <- function(app_json) {
+  appdir <- fs::path(".quarto", "_webr", "appdir")
+  destdir <- fs::path(".quarto", "_webr", "destdir")
+
+  # Build app directory, removing any previous app expanded there
+  if (fs::dir_exists(appdir)) {
+    fs::dir_delete(appdir)
+  }
+  fs::dir_create(appdir, recurse = TRUE)
+
+  # Convert app.json into files on disk, so we can use `renv::dependencies()`
+  app <- jsonlite::fromJSON(
+    app_json,
+    simplifyDataFrame = FALSE,
+    simplifyMatrix = FALSE
+  )
+  lapply(app, function (file) {
+    file_path <- fs::path(appdir, file$name)
+    if (file$type == "text") {
+      writeLines(file$content, file_path)
+    } else {
+      raw_content <- base64enc::base64decode(file$content, "raw")
+      writeBin(raw_content, file_path, useBytes = TRUE)
+    }
+  })
+
+  # Download wasm binaries ready to embed into Quarto deps
+  download_wasm_packages(appdir, destdir, verbose = FALSE, package_cache = TRUE)
+
+  # Enumerate R package Wasm binaries and prepare the VFS images as html deps
+  webr_dir <- fs::path(destdir, "shinylive", "webr")
+  packages_files <- dir(webr_dir, recursive = TRUE, full.names = FALSE)
+  packages_paths <- file.path("shinylive", "webr", packages_files)
+  packages_abs <- file.path(fs::path_abs(webr_dir), packages_files)
+
+  Map(
+    USE.NAMES = FALSE,
+    packages_paths,
+    packages_abs,
+    f = function(rel_common_file, abs_common_file) {
+      html_dep_obj(
+        name = rel_common_file,
+        path = abs_common_file
+      )
+    }
+  )
+}
 
 quarto_codeblock_to_json_path <- function() {
   file.path(assets_dir(), "scripts", "codeblock-to-json.js")

--- a/R/version.R
+++ b/R/version.R
@@ -1,3 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.2.3"
+SHINYLIVE_ASSETS_VERSION <- "0.2.8"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
+WEBR_R_VERSION <- "4.3.3"

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.2.8"
+SHINYLIVE_ASSETS_VERSION <- "0.3.0"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.3.3"

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -4,7 +4,15 @@
 \alias{export}
 \title{Export a Shiny app to a directory}
 \usage{
-export(appdir, destdir, ..., subdir = "", verbose = is_interactive())
+export(
+  appdir,
+  destdir,
+  ...,
+  subdir = "",
+  verbose = is_interactive(),
+  wasm_packages = TRUE,
+  package_cache = TRUE
+)
 }
 \arguments{
 \item{appdir}{Directory containing the application.}
@@ -17,6 +25,12 @@ export(appdir, destdir, ..., subdir = "", verbose = is_interactive())
 
 \item{verbose}{Print verbose output. Defaults to \code{TRUE} if running
 interactively.}
+
+\item{wasm_packages}{Download and include binary WebAssembly packages as
+part of the output app's static assets. Defaults to \code{TRUE}.}
+
+\item{package_cache}{Cache downloaded binary WebAssembly packages. Defaults
+to \code{TRUE}.}
 }
 \value{
 Nothing. The app is exported to \code{destdir}. Instructions for serving

--- a/man/quarto_ext.Rd
+++ b/man/quarto_ext.Rd
@@ -7,7 +7,8 @@
 quarto_ext(
   args = commandArgs(trailingOnly = TRUE),
   ...,
-  pretty = is_interactive()
+  pretty = is_interactive(),
+  con = "stdin"
 )
 }
 \arguments{
@@ -16,6 +17,8 @@ quarto_ext(
 \item{...}{Ignored.}
 
 \item{pretty}{Whether to pretty print the JSON output.}
+
+\item{con}{File from which to take input. Default: \code{"stdin"}.}
 }
 \value{
 Nothing. Values are printed to stdout.

--- a/tests/testthat/test-quarto_ext.R
+++ b/tests/testthat/test-quarto_ext.R
@@ -63,9 +63,22 @@ test_that("quarto_ext handles `extension app-resources`", {
 
   assets_ensure()
 
+  # Clean-up on exit
+  tmpdir <- tempdir()
+  wd <- setwd(tmpdir)
+  on.exit({
+    setwd(wd)
+    fs::dir_delete(tmpdir)
+  })
+
+  app_json <- '[{"name":"app.R","type":"text","content":"library(shiny)"}]'
+  writeLines(app_json, "app.json")
+
   txt <- collapse(capture.output({
-    quarto_ext(c("extension", "app-resources"))
+    quarto_ext(c("extension", "app-resources"), con = "app.json")
   }))
-  obj <- jsonlite::parse_json(txt)
-  expect_equal(obj, list())
+  resources <- jsonlite::parse_json(txt)
+
+  # Package metadata included in resources
+  expect_true(any(grepl("metadata.rds", vapply(resources, `[[`, character(1), "name"), fixed = TRUE)))
 })


### PR DESCRIPTION
Fixes #65 

----------

A first-pass implementation of #63.

Exports shinylive apps with Wasm R binary packages downloaded and included in `.../shinylive/webr/packages`. Metadata is stored in `.../shinylive/webr/packages/metadata.rds` and loaded at runtime.

For `shinylive::export()`, you can disable Wasm package bundling with `wasm_packages = FALSE`. And disable using the cache with `package_cache = FALSE`. Both are `TRUE` by default, meaning Wasm packages will be downloaded and bundled.

For Quarto documents with embedded R Shinylive apps, `quarto_ext.R` is updated so that `app.json` bundles passed to the `shinylive` R package are decoded onto disk, and then R Wasm binaries are downloaded using the same tools as created for `shinylive::export()`. Finally the resulting list of binaries are passed back to Quarto as HTML dependencies.

Metadata is merged over subsequent runs since (in e.g. Quarto docs) we can have multiple `app.json` bundles, and we want _all_ referenced packages to be available in the static assets.

---

Recursive dependencies are resolved using the `pkgdepends` package. This can get slow for large local package libraries (My R library has all of CRAN installed, for unrelated reasons, and so it takes a few seconds to resolve). We might want to think about how we could make use of `r-lib/pkgcache` in future. This should be "fine" for the moment, though.

---

Note: Requires the `shinylive` assets bundle from https://github.com/posit-dev/shinylive/pull/121