### PR TITLE
Switch from base64enc to jsonlite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ BugReports: https://github.com/posit-dev/r-shinylive/issues
 URL: https://posit-dev.github.io/r-shinylive/, https://github.com/posit-dev/r-shinylive
 Imports:
     archive,
-    base64enc,
     brio,
     fs,
     glue,

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -245,7 +245,7 @@ build_app_resources <- function(app_json) {
     if (file$type == "text") {
       writeLines(file$content, file_path)
     } else {
-      raw_content <- base64enc::base64decode(file$content, "raw")
+      raw_content <- jsonlite::base64_dec(file$content)
       writeBin(raw_content, file_path, useBytes = TRUE)
     }
   })

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -245,8 +245,10 @@ build_app_resources <- function(app_json) {
     if (file$type == "text") {
       writeLines(file$content, file_path)
     } else {
-      raw_content <- jsonlite::base64_dec(file$content)
-      writeBin(raw_content, file_path, useBytes = TRUE)
+      try({
+        raw_content <- jsonlite::base64_dec(file$content)
+        writeBin(raw_content, file_path, useBytes = TRUE)
+      })
     }
   })
 

--- a/tests/testthat/test-quarto_ext.R
+++ b/tests/testthat/test-quarto_ext.R
@@ -82,3 +82,30 @@ test_that("quarto_ext handles `extension app-resources`", {
   # Package metadata included in resources
   expect_true(any(grepl("metadata.rds", vapply(resources, `[[`, character(1), "name"), fixed = TRUE)))
 })
+
+test_that("quarto_ext handles `extension app-resources` with additional binary files", {
+  maybe_skip_test()
+
+  assets_ensure()
+
+  # Clean-up on exit
+  tmpdir <- tempdir()
+  wd <- setwd(tmpdir)
+  on.exit({
+    setwd(wd)
+    fs::dir_delete(tmpdir)
+  })
+
+  # A binary file included in app.json should successfully be decoded while
+  # building package metadata for app-resources.
+  app_json <- '[{"name":"app.R","type":"text","content":"library(shiny)"},{"name":"image.png","type":"binary","content":"iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg=="}]'
+  writeLines(app_json, "app.json")
+
+  txt <- collapse(capture.output({
+    quarto_ext(c("extension", "app-resources"), con = "app.json")
+  }))
+  resources <- jsonlite::parse_json(txt)
+
+  # Package metadata included in resources
+  expect_true(any(grepl("metadata.rds", vapply(resources, `[[`, character(1), "name"), fixed = TRUE)))
+})


### PR DESCRIPTION
Base64 decoding of files in `app.json` is currently broken by the changes in #72. This PR switches to `jsonlite`'s implementation (removing a dependency), and fixes the problem.

Also, use `try()` in the case of binary files so as to recover from a base64 decode error, since binary files likely don't affect the result of renv package dependency resolution in any case.