### PR TITLE
feat: Choose asset version at export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinylive (development version)
 
+* `export()` gains an `assets_version` argument to choose the version of the Shinylive web assets to be used with the exported app. This is primarily useful for testing new versions of the Shinylive assets before they're officially released via a package update. In CI and other automated workflow settings, the `SHINYLIVE_ASSETS_VERSION` environment variable can be used to set the assets version. (#91)
+
 # shinylive 0.1.1
 
 * Bump shinylive assets dependency to 0.2.3. (#38)

--- a/R/assets.R
+++ b/R/assets.R
@@ -361,7 +361,7 @@ assets_info <- function() {
 #'    assets version.
 #' @export
 assets_version <- function() {
-  SHINYLIVE_ASSETS_VERSION
+  Sys.getenv("SHINYLIVE_ASSETS_VERSION", SHINYLIVE_ASSETS_VERSION)
 }
 
 # """Checks if the URL for the Shinylive assets bundle is valid.

--- a/R/assets.R
+++ b/R/assets.R
@@ -358,7 +358,8 @@ assets_info <- function() {
 
 
 #' @describeIn assets Returns the version of the currently supported Shinylive
-#'    assets version.
+#'    assets version. If the `SHINYLIVE_ASSETS_VERSION` environment variable is set,
+#'    that value will be used.
 #' @export
 assets_version <- function() {
   Sys.getenv("SHINYLIVE_ASSETS_VERSION", SHINYLIVE_ASSETS_VERSION)

--- a/R/deps.R
+++ b/R/deps.R
@@ -221,7 +221,7 @@ shinylive_common_dep_htmldep <- function(
   quarto_html_dependency_obj(
     # MUST be called `"shinylive"` to match quarto ext name
     name = "shinylive",
-    version = SHINYLIVE_ASSETS_VERSION,
+    version = assets_version(),
     scripts = scripts,
     stylesheets = stylesheets,
     resources = resources

--- a/R/deps.R
+++ b/R/deps.R
@@ -75,28 +75,28 @@ quarto_html_dependency_obj <- function(
   )
 }
 
-shinylive_base_deps_htmldep <- function(sw_dir = NULL) {
+shinylive_base_deps_htmldep <- function(sw_dir = NULL, version = assets_version()) {
   list(
-    serviceworker_dep(sw_dir),
-    shinylive_common_dep_htmldep("base")
+    serviceworker_dep(sw_dir, version = version),
+    shinylive_common_dep_htmldep("base", version = version)
   )
 }
-shinylive_r_resources <- function() {
-  shinylive_common_dep_htmldep("r")$resources
+shinylive_r_resources <- function(version = assets_version()) {
+  shinylive_common_dep_htmldep("r", version = version)$resources
 }
 # Not used in practice!
-shinylive_python_resources <- function(sw_dir = NULL) {
-  shinylive_common_dep_htmldep("python")$resources
+shinylive_python_resources <- function(sw_dir = NULL, version = assets_version()) {
+  shinylive_common_dep_htmldep("python", version = version)$resources
 }
 
 
-serviceworker_dep <- function(sw_dir) {
+serviceworker_dep <- function(sw_dir, version = assets_version()) {
   quarto_html_dependency_obj(
     name = "shinylive-serviceworker",
-    version = SHINYLIVE_ASSETS_VERSION,
+    version = version,
     serviceworkers = list(
       html_dep_serviceworker_obj(
-        source = file.path(assets_dir(), "shinylive-sw.js"),
+        source = file.path(assets_dir(version = version), "shinylive-sw.js"),
         destination = "/shinylive-sw.js"
       )
     ),
@@ -117,8 +117,11 @@ serviceworker_dep <- function(sw_dir) {
 # dependencies; in other words, the files that are always included in a
 # Shinylive deployment.
 # """
-shinylive_common_dep_htmldep <- function(dep_type = c("base", "python", "r")) {
-  assets_path <- assets_dir()
+shinylive_common_dep_htmldep <- function(
+  dep_type = c("base", "python", "r"),
+  version = assets_version()
+) {
+  assets_path <- assets_dir(version = version)
   # In quarto ext, keep support for python engine
   rel_common_files <- shinylive_common_files(dep_type = dep_type)
   abs_common_files <- file.path(assets_path, rel_common_files)
@@ -230,11 +233,14 @@ shinylive_common_dep_htmldep <- function(dep_type = c("base", "python", "r")) {
 # Return a list of files that are base dependencies; in other words, the files
 # that are always included in a Shinylive deployment.
 # """
-shinylive_common_files <- function(dep_type = c("base", "python", "r")) {
+shinylive_common_files <- function(
+  dep_type = c("base", "python", "r"),
+  version = assets_version()
+) {
   dep_type <- match.arg(dep_type)
-  assets_ensure()
+  assets_ensure(version = version)
 
-  assets_folder <- assets_dir()
+  assets_folder <- assets_dir(version = version)
   # # `dir()` is 10x faster than `fs::dir_ls()`
   # common_files <- dir(assets_folder, recursive = TRUE)
 

--- a/R/export.R
+++ b/R/export.R
@@ -77,7 +77,11 @@ export <- function(
     "Copying base Shinylive files from ", assets_path, "/ to ", destdir, "/"
   )
   # When exporting, we know it is only an R app. So remove python support
-  base_files <- c(shinylive_common_files("base"), shinylive_common_files("r"))
+  base_files <- c(
+    shinylive_common_files("base", version = assets_version),
+    shinylive_common_files("r", version = assets_version)
+  )
+
   if (verbose) {
     p <- progress::progress_bar$new(
       format = "[:bar] :percent\n",

--- a/R/export.R
+++ b/R/export.R
@@ -12,6 +12,8 @@
 #'    part of the output app's static assets. Defaults to `TRUE`.
 #' @param package_cache Cache downloaded binary WebAssembly packages. Defaults
 #'    to `TRUE`.
+#' @param assets_version The version of the Shinylive assets to use in the
+#'    exported app. Defaults to [assets_version()].
 #' @param ... Ignored
 #' @export
 #' @return Nothing. The app is exported to `destdir`. Instructions for serving
@@ -35,7 +37,9 @@ export <- function(
     subdir = "",
     verbose = is_interactive(),
     wasm_packages = TRUE,
-    package_cache = TRUE) {
+    package_cache = TRUE,
+    assets_version = assets_version()
+) {
   verbose_print <- if (verbose) message else list
 
   stopifnot(fs::is_dir(appdir))
@@ -63,7 +67,7 @@ export <- function(
   mark_file <- cp_funcs$mark_file
   copy_files <- cp_funcs$copy_files
 
-  assets_path <- assets_dir()
+  assets_path <- assets_dir(version = assets_version)
 
   # =========================================================================
   # Copy the base dependencies for shinylive/ distribution. This does not

--- a/R/export.R
+++ b/R/export.R
@@ -38,9 +38,12 @@ export <- function(
     verbose = is_interactive(),
     wasm_packages = TRUE,
     package_cache = TRUE,
-    assets_version = assets_version()
+    assets_version = NULL
 ) {
   verbose_print <- if (verbose) message else list
+  if (is.null(assets_version)) {
+    assets_version <- assets_version()
+  }
 
   stopifnot(fs::is_dir(appdir))
   if (!(

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -183,7 +183,7 @@ quarto_ext <- function(
     "info" = {
       list(
         "version" = SHINYLIVE_R_VERSION,
-        "assets_version" = SHINYLIVE_ASSETS_VERSION,
+        "assets_version" = assets_version(),
         "scripts" = list(
           "codeblock-to-json" = quarto_codeblock_to_json_path()
         )

--- a/man/assets.Rd
+++ b/man/assets.Rd
@@ -72,6 +72,7 @@ the one used by the current version of \pkg{shinylive}.
 assets that have been installed.
 
 \item \code{assets_version()}: Returns the version of the currently supported Shinylive
-assets version.
+assets version. If the \code{SHINYLIVE_ASSETS_VERSION} environment variable is set,
+that value will be used.
 
 }}

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -11,7 +11,8 @@ export(
   subdir = "",
   verbose = is_interactive(),
   wasm_packages = TRUE,
-  package_cache = TRUE
+  package_cache = TRUE,
+  assets_version = NULL
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ part of the output app's static assets. Defaults to \code{TRUE}.}
 
 \item{package_cache}{Cache downloaded binary WebAssembly packages. Defaults
 to \code{TRUE}.}
+
+\item{assets_version}{The version of the Shinylive assets to use in the
+exported app. Defaults to \code{\link[=assets_version]{assets_version()}}.}
 }
 \value{
 Nothing. The app is exported to \code{destdir}. Instructions for serving


### PR DESCRIPTION
Adds a new `assets_version` argument to `export()` that then propagates throughout the export process. This makes it possible to use `shinylive::export()` with asset versions other than the one currently used by default in the package.

The primary use case was to allow me to use the 0.4.1 assets even though the package is currently tied to 0.3.0. I used this to be able to use the preview version of shinylive with the wasm package library before it was officially tied to the package.

With this change `assets_version()` reports the current default version used by the package. Users may either set `assets_version` when calling `export()` or they may use the `SHINYLIVE_ASSETS_VERSION` envvar to achieve the same thing. The envvar is necessary for CI environments where it's easy to set this variable but hard to provide a version to the right function call, which is hidden from the user inside a GitHub workflow.

Note that setting `assets_version` is enough, `assets_ensure()` will find the require assets version and download it as necessary.

We don't currently do minimum version checking; in the future we would still update the default assets version used by the package. If we ever have a breaking change where the `r-shinylive` package would be incompatible with older versions, we could include a version check in a central place, probably in `assets_ensure()`.