### PR TITLE
tests(export): Refactor export tests to use test files

### DIFF
--- a/tests/testthat/apps/app-r/app.R
+++ b/tests/testthat/apps/app-r/app.R
@@ -1,0 +1,14 @@
+library(shiny)
+
+ui <- fluidPage(
+  sliderInput("n", "N", 0, 100, 40),
+  verbatimTextOutput("txt", placeholder = TRUE),
+)
+
+server <- function(input, output) {
+  output$txt <- renderText({
+      paste0("The value of n*2 is ", 2 * input$n)
+  })
+}
+
+shinyApp(ui, server)

--- a/tests/testthat/apps/server-r/global.R
+++ b/tests/testthat/apps/server-r/global.R
@@ -1,0 +1,2 @@
+library(shiny)
+global_value <- 50

--- a/tests/testthat/apps/server-r/server.R
+++ b/tests/testthat/apps/server-r/server.R
@@ -1,0 +1,7 @@
+library(shiny)
+
+shinyServer(function(input, output, session) {
+  output$txt <- renderText({
+    paste0("The value of n*2 is ", 2 * input$n)
+  })
+})

--- a/tests/testthat/apps/server-r/ui.R
+++ b/tests/testthat/apps/server-r/ui.R
@@ -1,0 +1,6 @@
+library(shiny)
+
+shinyUI(fluidPage(
+  sliderInput("n", "N", 0, 100, 40),
+  verbatimTextOutput("txt", placeholder = TRUE),
+))


### PR DESCRIPTION
Makes it easier to use the test fixtures for interactive testing and development