### PR TITLE
ci(integration): Coordinate tested assets versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -84,15 +84,16 @@ jobs:
         id: r-linked-assets
         shell: Rscript {0}
         run: |
+          shinylive_local_version <- shinylive:::package_json_version("shinylive_assets")
+          shinylive::assets_remove(shinylive_local_version)
           shinylive::assets_install_copy("shinylive_assets")
           shinylive::assets_info()
           cat(
-            "version=", shinylive:::package_json_version("shinylive_assets"),
+            "version=", shinylive_local_version,
             file = Sys.getenv("GITHUB_OUTPUT"),
             append = TRUE,
             sep = ""
           )
-
 
       - name: Update lua script for debugging
         shell: Rscript {0}
@@ -133,15 +134,12 @@ jobs:
           shinylive::assets_ensure()
 
           testthat::test_local()
-      
-      - name: Link shinylive assets for py-shinylive
-        shell: bash
-        run: |
-          shinylive assets link-from-local shinylive_assets/build
 
       - name: Test shinylive quarto extension with latest shinylive assets
         uses: quarto-dev/quarto-actions/render@v2
         env:
+          # TODO: py-shinylive doesn't follow this envvar yet. If shinylive
+          # has a newer version, this action will fail.
           SHINYLIVE_ASSETS_VERSION: ${{ steps.r-linked-assets.outputs.version }}
         with:
           path: local/quarto/

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -37,10 +37,12 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: Install py-shinylive
+        id: py-shinylive
         shell: bash
         run: |
           pip install shinylive
           # pip install https://github.com/posit-dev/py-shinylive/archive/split_api.zip
+          echo "version=$(shinylive assets version)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -124,10 +126,14 @@ jobs:
           shinylive::assets_ensure()
 
           testthat::test_local()
+      
       # If this (^^) completes, it is a big success!
       # Run quarto test after testthat test
       - name: Test shinylive quarto extension can build
         uses: quarto-dev/quarto-actions/render@v2
+        env:
+          # Test r-shinylive against the same shinylive assets as py-shinylive
+          SHINYLIVE_ASSETS_VERSION: ${{ steps.py-shinylive.outputs.version }}
         with:
           path: local/quarto/
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,10 +72,19 @@ jobs:
           make all
 
       - name: Link shinylive assets
+        id: r-linked-assets
         shell: Rscript {0}
         run: |
           shinylive::assets_install_copy("shinylive_assets")
           shinylive::assets_info()
+          cat(
+            "version=", shinylive:::package_json_version("shinylive_assets"),
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE,
+            sep = ""
+          )
+
+
       - name: Update lua script for debugging
         shell: Rscript {0}
         run: |
@@ -104,6 +113,7 @@ jobs:
       - name: Run shinylive R package tests
         env:
           TEST_ASSETS: "TRUE"
+          SHINYLIVE_ASSETS_VERSION: ${{ steps.r-linked-assets.outputs.version }}
         shell: Rscript {0}
         run: |
           shinylive::assets_info()

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -127,12 +127,23 @@ jobs:
 
           testthat::test_local()
       
+      - name: Link shinylive assets for py-shinylive
+        shell: bash
+        run: |
+          shinylive assets link-from-local shinylive_assets/build
+      
       # If this (^^) completes, it is a big success!
       # Run quarto test after testthat test
-      - name: Test shinylive quarto extension can build
+      - name: Test shinylive quarto extension with latest shinylive assets
         uses: quarto-dev/quarto-actions/render@v2
         env:
-          # Test r-shinylive against the same shinylive assets as py-shinylive
+          SHINYLIVE_ASSETS_VERSION: ${{ steps.r-linked-assets.outputs.version }}
+        with:
+          path: local/quarto/
+
+      - name: Test shinylive quarto extension with py-shinylive assets version
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
           SHINYLIVE_ASSETS_VERSION: ${{ steps.py-shinylive.outputs.version }}
         with:
           path: local/quarto/

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -126,25 +126,25 @@ jobs:
           shinylive::assets_ensure()
 
           testthat::test_local()
+
+      # If this (^^) completes, it is a big success!
+      # Run quarto test after testthat test
+      - name: Test shinylive quarto extension with py-shinylive assets version
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          SHINYLIVE_ASSETS_VERSION: ${{ steps.py-shinylive.outputs.version }}
+        with:
+          path: local/quarto/
       
       - name: Link shinylive assets for py-shinylive
         shell: bash
         run: |
           shinylive assets link-from-local shinylive_assets/build
-      
-      # If this (^^) completes, it is a big success!
-      # Run quarto test after testthat test
+
       - name: Test shinylive quarto extension with latest shinylive assets
         uses: quarto-dev/quarto-actions/render@v2
         env:
           SHINYLIVE_ASSETS_VERSION: ${{ steps.r-linked-assets.outputs.version }}
-        with:
-          path: local/quarto/
-
-      - name: Test shinylive quarto extension with py-shinylive assets version
-        uses: quarto-dev/quarto-actions/render@v2
-        env:
-          SHINYLIVE_ASSETS_VERSION: ${{ steps.py-shinylive.outputs.version }}
         with:
           path: local/quarto/
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -60,6 +60,13 @@ jobs:
         with:
           needs: quarto
 
+      - name: Test shinylive quarto extension with py-shinylive assets version
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          SHINYLIVE_ASSETS_VERSION: ${{ steps.py-shinylive.outputs.version }}
+        with:
+          path: local/quarto/
+
       - name: Check out 'posit-dev/shinylive' repo into './shinylive_assets'
         uses: actions/checkout@v4
         with:
@@ -126,15 +133,6 @@ jobs:
           shinylive::assets_ensure()
 
           testthat::test_local()
-
-      # If this (^^) completes, it is a big success!
-      # Run quarto test after testthat test
-      - name: Test shinylive quarto extension with py-shinylive assets version
-        uses: quarto-dev/quarto-actions/render@v2
-        env:
-          SHINYLIVE_ASSETS_VERSION: ${{ steps.py-shinylive.outputs.version }}
-        with:
-          path: local/quarto/
       
       - name: Link shinylive assets for py-shinylive
         shell: bash

--- a/tests/testthat/test-quarto_ext.R
+++ b/tests/testthat/test-quarto_ext.R
@@ -8,7 +8,7 @@ test_that("quarto_ext handles `extension info`", {
   }))
   info <- jsonlite::parse_json(txt)
   expect_equal(info$version, as.character(utils::packageVersion("shinylive")))
-  expect_equal(info$assets_version, SHINYLIVE_ASSETS_VERSION)
+  expect_equal(info$assets_version, assets_version())
 
   expect_true(
     is.list(info$scripts) &&


### PR DESCRIPTION
Three big changes:

1. We now run the R package tests using the shinylive assets we built and installed in the previous steps (before we were building shinylive but testing with the default assets version).
2. We now test r-shinylive in Quarto against the same version of shinylive as is used by py-shinylive. To do this, we needed to move the quarto integration test to happen immediately after installing the r-shinylive package, to ensure that we get the released shinylive assets. Later, we'll build and install the latest shinylive, which may have the same version number as the last release (but will be different).
3. Finally, we also test r/py-shinylive together in Quarto using the latest, custom built shinylive.