### PR TITLE
feat: Use {cli} for console printing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ BugReports: https://github.com/posit-dev/r-shinylive/issues
 Imports:
     archive,
     brio,
+    cli,
     fs,
     gh,
     glue,
@@ -38,7 +39,8 @@ Imports:
     renv,
     rlang,
     tools,
-    whisker
+    whisker,
+    withr
 Suggests:
     httpuv (>= 1.6.12),
     pkgcache,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
     * `template_params` takes a list of parameters to be interpolated into the template. The default template include `title` (the title for the page with the exported app), `include_in_head` (HTML added to the `<head>` of the page), and `include_before_body` (HTML added just after `<body>`) and `include_after_body` (HTML added just after `</body>`).
     * `template_dir` is the directory containing the template files. The default is the `export_template` directory of the shinylive assets being used for the export. Use `assets_info()` to locate installed shinylive assets where you can find the default template files.
 
+* shinylive now uses `{cli}` for console printing. Console output can be suppressed via the global R option by calling `options(shinylive.quiet = TRUE)`. (#104)
+
+* `export()` and `assets_info()` gain a `quiet` argument. In `export()`, `quiet` replaces the now-deprecated `verbose` option, which continues to work with a warning. (#104)
+
 # shinylive 0.1.1
 
 * Bump shinylive assets dependency to 0.2.3. (#38)

--- a/R/app_json.R
+++ b/R/app_json.R
@@ -115,10 +115,10 @@ read_app_files <- function(
 
         cur_basename <- basename(cur_path)
         if (cur_basename == "shinylive.js") {
-          message(
-            "Warning: Found shinylive.js in source directory '", curdur, "'.",
-            " Are you including a shinylive distribution in your app?"
-          )
+          cli::cli_warn(c(
+            "Warning: Found {.path shinylive.js} in source directory {.path {curdur}}.",
+            i = "Are you including a shinylive distribution in your app?"
+          ))
         }
 
         # Get file content
@@ -157,9 +157,10 @@ write_app_json <- function(
   destdir,
   template_dir,
   template_params = list(),
-  verbose = is_interactive()
+  quiet = getOption("shinylive.quiet", FALSE)
 ) {
-  verbose_print <- if (isTRUE(verbose)) message else list
+  local_quiet(quiet)
+
   stopifnot(inherits(app_info, APP_INFO_CLASS))
   # stopifnot(fs::dir_exists(destdir))
   stopifnot(fs::dir_exists(template_dir))
@@ -205,12 +206,15 @@ write_app_json <- function(
 
   app_json_output_file <- fs::path(app_destdir, "app.json")
 
-  verbose_print("Writing ", app_json_output_file, appendLF = FALSE)
+  cli_progress_step("Writing {.path {app_json_output_file}}")
   jsonlite::write_json(
     app_info$files,
     path = app_json_output_file,
     auto_unbox = TRUE,
     pretty = FALSE
   )
-  verbose_print(": ", fs::file_info(app_json_output_file)$size[1], " bytes")
+  cli_progress_done()
+  cli_alert_info("Wrote {.path {app_json_output_file}} ({fs::file_info(app_json_output_file)$size[1]} bytes)")
+  
+  invisible(app_json_output_file)
 }

--- a/R/assets.R
+++ b/R/assets.R
@@ -40,17 +40,17 @@ assets_download <- function(
     add = TRUE
   )
 
-  message("Downloading shinylive assets v", version, "...")
+  cli_progress_step("Downloading shinylive assets {.field v{version}}")
   req <- httr2::request(url)
   req <- httr2::req_progress(req)
   httr2::req_perform(req, path = tmp_targz)
-  message("") # Newline after progress bar
-
-  message("Unzipping to ", dir, "/")
+  
+  cli_progress_step("Unzipping shinylive assets to {.path {dir}}")
   fs::dir_create(dir)
   archive::archive_extract(tmp_targz, dir)
-
-  invisible()
+  
+  cli_progress_done()
+  invisible(dir)
 }
 
 
@@ -108,7 +108,10 @@ install_local_helper <- function(
   stopifnot(fs::dir_exists(assets_repo_dir))
   repo_build_dir <- fs::path(assets_repo_dir, "build")
   if (!fs::dir_exists(repo_build_dir)) {
-    stop("Assets repo build dir does not exist (`", repo_build_dir, "`).\nHave you called `make all` yet?")
+    cli::cli_abort(c(
+      "Assets repo build dir does not exist ({.path {repo_build_dir}}).",
+      i = "Have you called {.code make all} yet?"
+    ))
   }
   target_dir <- assets_dir_impl(dir = dir, version = version)
 
@@ -116,12 +119,12 @@ install_local_helper <- function(
   install_fn(repo_build_dir, target_dir)
 
   if (version != assets_version()) {
-    message(
-      "Warning: You are installing a local copy of shinylive assets that is not the same as the version used by the shinylive R package.",
-      "\nWarning: Unexpected behavior may occur!",
-      "\n\nNew assets version: ", version,
-      "\nSupported assets version: ", assets_version()
-    )
+    cli::cli_warn(c(
+      "You are installing a local copy of shinylive assets that is not the same as the version used by the shinylive R package.",
+      "Unexpected behavior may occur!",
+      x = "New assets version: {version}",
+      i = "Supported assets version: {assets_version()}"
+    ))
   }
 }
 
@@ -204,13 +207,13 @@ assets_ensure <- function(
 ) {
   stopifnot(length(list(...)) == 0)
   if (!fs::dir_exists(dir)) {
-    message("Creating assets cache directory ", dir)
+    cli_alert_info("Creating assets cache directory ", dir)
     fs::dir_create(dir)
   }
 
   assets_path <- assets_dir(version, dir = dir)
   if (!fs::dir_exists(assets_path)) {
-    message("`", assets_path, "` assets directory does not exist.")
+    cli_alert_warning("{.path {assets_path}} assets directory does not exist.")
     assets_download(url = url, version = version, dir = dir)
   }
 
@@ -246,7 +249,7 @@ assets_cleanup <- function(
     character(1)
   )
   if (assets_version() %in% versions) {
-    message("Keeping version ", assets_version())
+    cli_alert_info("Keeping version {assets_version()}")
     versions <- setdiff(versions, assets_version())
   }
 
@@ -286,10 +289,10 @@ assets_remove <- function(
   lapply(versions, function(version) {
     target_dir <- assets_dir_impl(dir = dir, version = version)
     if (fs::dir_exists(target_dir)) {
-      message("Removing ", target_dir)
+      cli_progress_step("Removing {.path {target_dir}}")
       unlink_path(target_dir)
     } else {
-      message(target_dir, " folder does not exist")
+      cli_alert_warning("{.path {target_dir}} folder does not exist")
     }
   })
 
@@ -342,24 +345,22 @@ assets_info <- function() {
     installed_versions <- "(None)"
   }
 
-  cat(
-    collapse(c(
-      paste0("shinylive R package version:  ", SHINYLIVE_R_VERSION),
-      paste0("shinylive web assets version: ", assets_version()),
-      "",
-      "Local cached shinylive asset dir:",
-      collapse("    ", assets_cache_dir()),
-      "",
-      "Installed assets:",
-      if (assets_cache_dir_exists()) {
-        collapse("    ", installed_versions)
-      } else {
-        "    (Cache dir does not exist)"
-      },
-      ""
-    )),
-    sep = ""
-  )
+  cli_text("shinylive R package version: {.field {SHINYLIVE_R_VERSION}}")
+  cli_text("shinylive web assets version: {.field {assets_version()}}")
+  cli_text("")
+  cli_text("Local cached shinylive asset dir:")
+  cli_bullets(c(">" = "{.path {assets_cache_dir()}}"))
+  cli_text("")
+  cli_text("Installed assets:")
+  if (assets_cache_dir_exists()) {
+    cli_installed <- c()
+    for (i in seq_along(installed_versions)) {
+      cli_installed <- c(cli_installed, c("*" = sprintf("{.path {installed_versions[%s]}}", i)))
+    }
+    cli_bullets(cli_installed)
+  } else {
+    cli_bullets("(Cache dir does not exist)")
+  }
 
   versions <- vapply(
     strsplit(installed_versions, "shinylive-", fixed = TRUE),

--- a/R/assets.R
+++ b/R/assets.R
@@ -336,14 +336,19 @@ assets_dirs <- function(
 
 
 
-#' @describeIn assets Prints information about the local shinylive
-#'    assets that have been installed.
+#' @describeIn assets Prints information about the local shinylive assets that
+#'   have been installed. Invisibly returns a table of installed asset versions
+#'   and their associated paths.
+#' @param quiet In `assets_info()`, if `quiet = TRUE`, the function will not
+#'   print the assets information to the console.
 #' @export
-assets_info <- function() {
+assets_info <- function(quiet = FALSE) {
   installed_versions <- assets_dirs()
   if (length(installed_versions) == 0) {
     installed_versions <- "(None)"
   }
+
+  local_quiet(quiet)
 
   cli_text("shinylive R package version: {.field {SHINYLIVE_R_VERSION}}")
   cli_text("shinylive web assets version: {.field {assets_version()}}")
@@ -376,7 +381,7 @@ assets_info <- function() {
 
   class(data) <- c("tbl_df", "tbl", "data.frame")
 
-  invisible(data)
+  if (is_quiet()) data else invisible(data)
 }
 
 

--- a/R/cli.R
+++ b/R/cli.R
@@ -1,0 +1,47 @@
+local_quiet <- function(quiet = FALSE, .envir = parent.frame()) {
+  withr::local_options(list(shinylive.quiet = quiet), .local_envir = .envir)
+}
+
+is_quiet <- function() {
+  isTRUE(getOption("shinylive.quiet", FALSE))
+}
+
+cli_alert <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_alert(..., .envir = .envir)
+}
+
+cli_alert_info <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_alert_info(..., .envir = .envir)
+}
+
+cli_alert_warning <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_alert_warning(..., .envir = .envir)
+}
+
+cli_alert_success <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_alert_success(..., .envir = .envir)
+}
+
+cli_progress_step <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_progress_step(..., .envir = .envir)
+}
+
+cli_progress_done <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_progress_done(..., .envir = .envir)
+}
+
+cli_text <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_text(..., .envir = .envir)
+}
+
+cli_bullets <- function(..., .envir = parent.frame()) {
+  if (is_quiet()) return(invisible())
+  cli::cli_bullets(..., .envir = .envir)
+}

--- a/R/deps.R
+++ b/R/deps.R
@@ -206,7 +206,7 @@ shinylive_common_dep_htmldep <- function(
 
       # Put load-shinylive-sw.js in the scripts first
       if (is.null(load_shinylive_dep)) {
-        stop("load-shinylive-sw.js not found in assets")
+        cli::cli_abort("{.path load-shinylive-sw.js} not found in assets")
       }
       scripts <- c(list(load_shinylive_dep), scripts)
 
@@ -216,7 +216,7 @@ shinylive_common_dep_htmldep <- function(
       }
     },
     {
-      stop("unknown dep_type: ", dep_type)
+      cli::cli_abort("Unknown {.var dep_type}: {.val dep_type}")
     }
   )
 
@@ -297,7 +297,7 @@ shinylive_common_files <- function(
         )
       },
       {
-        stop("unknown dep_type: ", dep_type)
+        cli::cli_abort("Unknown {.var dep_type}: {.val dep_type}")
       }
     )
 

--- a/R/export.R
+++ b/R/export.R
@@ -57,12 +57,12 @@ export <- function(
   ...,
   subdir = "",
   quiet = getOption("shinylive.quiet", !is_interactive()),
-  verbose = NULL,
   wasm_packages = TRUE,
   package_cache = TRUE,
   assets_version = NULL,
   template_dir = NULL,
-  template_params = list()
+  template_params = list(),
+  verbose = NULL
 ) {
   if (!is.null(verbose)) {
     rlang::warn("The {.var verbose} argument is deprecated. Use {.var quiet} instead.")

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,7 @@ collapse <- function(...) {
 package_json_version <- function(source_dir) {
   package_json_path <- fs::path(source_dir, "package.json")
   if (!fs::file_exists(package_json_path)) {
-    stop("package.json does not exist in ", source_dir)
+    cli::cli_abort("{.field package.json} does not exist in {.path {source_dir}}")
   }
 
   package_json <- jsonlite::read_json(package_json_path)
@@ -66,29 +66,25 @@ drop_nulls_rec <- function(x) {
 # 1. Mark all files to be copied
 # 2. Copy all files
 # IO operations are slow in R. It is faster to call `fs::file_copy()` with a large vector than many times with single values.
-create_copy_fn <- function(
-  overwrite = FALSE,
-  verbose_print = list # or `message`
-) {
+create_copy_fn <- function(overwrite = FALSE) {
   overwrite <- isTRUE(overwrite)
-  stopifnot(is.function(verbose_print))
 
   file_list <- list()
 
   mark_file <- function(src_file_path, dst_file_path) {
     if (file.exists(dst_file_path)) {
       if (!files_are_equal(src_file_path, dst_file_path)) {
-        message(
-          "\nSource and destination copies differ:", dst_file_path,
-          "\nThis is probably because your shinylive sources have been updated and differ from the copy in the exported app.",
-          "\nYou probably should remove the export directory and re-export the application."
-        )
+        cli::cli_inform(c(
+          x = "Source and destination copies differ for {.path {dst_file_path}}",
+          "!" = "This is probably because your shinylive sources have been updated and differ from the copy in the exported app.",
+          i = "You probably should remove the export directory and re-export the application."
+        ))
       }
       if (overwrite) {
-        verbose_print(paste0("\nRemoving ", dst_file_path))
+        # cli_alert_warning("Removing {.path {dst_file_print}}")
         unlink_path(dst_file_path)
       } else {
-        verbose_print(paste0("\nSkipping ", dst_file_path))
+        # cli_alert("Skipping {.path {dst_file_print}}")
         return()
       }
     } else {

--- a/man/assets.Rd
+++ b/man/assets.Rd
@@ -27,7 +27,7 @@ assets_cleanup(..., dir = assets_cache_dir())
 
 assets_remove(versions, ..., dir = assets_cache_dir())
 
-assets_info()
+assets_info(quiet = FALSE)
 
 assets_version()
 }
@@ -43,6 +43,9 @@ should be used.}
 behavior should be used.}
 
 \item{versions}{The assets versions to remove.}
+
+\item{quiet}{In \code{assets_info()}, if \code{quiet = TRUE}, the function will not
+print the assets information to the console.}
 }
 \value{
 \code{assets_version()} returns the version of the currently supported Shinylive.
@@ -68,8 +71,9 @@ the one used by the current version of \pkg{shinylive}.
 
 \item \code{assets_remove()}: Removes a local copies of shinylive web assets.
 
-\item \code{assets_info()}: Prints information about the local shinylive
-assets that have been installed.
+\item \code{assets_info()}: Prints information about the local shinylive assets that
+have been installed. Invisibly returns a table of installed asset versions
+and their associated paths.
 
 \item \code{assets_version()}: Returns the version of the currently supported Shinylive
 assets version. If the \code{SHINYLIVE_ASSETS_VERSION} environment variable is set,

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -9,7 +9,8 @@ export(
   destdir,
   ...,
   subdir = "",
-  verbose = is_interactive(),
+  quiet = getOption("shinylive.quiet", !is_interactive()),
+  verbose = NULL,
   wasm_packages = TRUE,
   package_cache = TRUE,
   assets_version = NULL,
@@ -26,8 +27,11 @@ export(
 
 \item{subdir}{Subdirectory of \code{destdir} to write the app to.}
 
-\item{verbose}{Print verbose output. Defaults to \code{TRUE} if running
-interactively.}
+\item{quiet}{Suppress console output during export. Follows the global
+\code{shinylive.quiet} option or defaults to \code{FALSE} in interactive sessions if
+not set.}
+
+\item{verbose}{Deprecated, please use \code{quiet} instead.}
 
 \item{wasm_packages}{Download and include binary WebAssembly packages as
 part of the output app's static assets. Defaults to \code{TRUE}.}

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -10,12 +10,12 @@ export(
   ...,
   subdir = "",
   quiet = getOption("shinylive.quiet", !is_interactive()),
-  verbose = NULL,
   wasm_packages = TRUE,
   package_cache = TRUE,
   assets_version = NULL,
   template_dir = NULL,
-  template_params = list()
+  template_params = list(),
+  verbose = NULL
 )
 }
 \arguments{
@@ -30,8 +30,6 @@ export(
 \item{quiet}{Suppress console output during export. Follows the global
 \code{shinylive.quiet} option or defaults to \code{FALSE} in interactive sessions if
 not set.}
-
-\item{verbose}{Deprecated, please use \code{quiet} instead.}
 
 \item{wasm_packages}{Download and include binary WebAssembly packages as
 part of the output app's static assets. Defaults to \code{TRUE}.}
@@ -64,6 +62,8 @@ following parameters:
 HTML to be included in the \verb{<head>}, just after the opening \verb{<body>},
 or just before the closing \verb{</body>} tag, respectively.
 }}
+
+\item{verbose}{Deprecated, please use \code{quiet} instead.}
 }
 \value{
 Nothing. The app is exported to \code{destdir}. Instructions for serving

--- a/tests/testthat/test-export.R
+++ b/tests/testthat/test-export.R
@@ -1,3 +1,10 @@
+expect_silent_unattended <- function(expr) {
+  if (interactive()) {
+    return(expr)
+  }
+  expect_silent(expr)
+}
+
 test_that("export - app.R", {
   maybe_skip_test()
 
@@ -12,7 +19,7 @@ test_that("export - app.R", {
 
   app_dir <- test_path("apps", "app-r")
 
-  expect_silent({
+  expect_silent_unattended({
     export(app_dir, out_dir)
   })
 
@@ -26,7 +33,7 @@ test_that("export - app.R", {
   )
   expect_setequal(dir(file.path(out_dir, "edit")), asset_edit_files)
 
-  expect_silent({
+  expect_silent_unattended({
     export(app_dir, out_dir, subdir = "test_subdir")
   })
 
@@ -54,7 +61,7 @@ test_that("export - server.R", {
   app_dir <- test_path("apps", "server-r")
 
   # Verify global.R / ui.R / server.R app can be exported
-  expect_silent({
+  expect_silent_unattended({
     export(app_dir, out_dir)
   })
   
@@ -91,7 +98,7 @@ test_that("export with template", {
 
   app_dir <- test_path("apps", "app-r")
 
-  expect_silent({
+  expect_silent_unattended({
     export(
       app_dir,
       out_dir,


### PR DESCRIPTION
* Use cli for command line printing
* cli functions are called through wrappers that respect the `shinylive.quiet` global option and no-op if `quiet = TRUE`.
* `export(verbose=)` is deprecated in favor of `quiet`
* `assets_info()` gains a `quiet` argument
* Overly verbose file-copying messages are now suppressed in `export()`.