### PR TITLE
Restore short R version in r-wasm repo URLs

### DIFF
--- a/R/packages.R
+++ b/R/packages.R
@@ -11,7 +11,7 @@ resolve_dependencies <- function(pkgs, local = TRUE) {
   unique(inst$get_resolution()$package)
 }
 
-warn_repo_pkg_version <- function(desc, ver) {
+check_repo_pkg_version <- function(desc, ver) {
   # Show a warning if packages major.minor versions differ
   # We don't worry too much about patch, since webR versions of packages may be
   # patched at the repo for compatibility with Emscripten
@@ -39,7 +39,7 @@ get_default_wasm_assets <- function(desc) {
   }
 
   ver <- info[pkg, "Version", drop = TRUE]
-  warn_repo_pkg_version(desc, ver)
+  check_repo_pkg_version(desc, ver)
 
   list(
     list(
@@ -66,7 +66,7 @@ get_r_universe_wasm_assets <- function(desc) {
   }
 
   ver <- info[pkg, "Version", drop = TRUE]
-  warn_repo_pkg_version(desc, ver)
+  check_repo_pkg_version(desc, ver)
 
   list(
     list(


### PR DESCRIPTION
For a previous version of webR, we required the full R version to be included as part of r-wasm repo URLs for Emscripten ABI compatability reasons. This was a temporary measure and is no longer required for the latest release of webR.

This PR restores the original short R versioning in repo.r-wasm.org URLs, matching the base R and r-universe behaviour.

The TODO mentioned combining two functions (one for r-wasm, the other for r-universe) but I've decided not to in case we diverge again in the future. Instead, I've just abstracted out the logic for showing a warning message when native and Wasm package versions don't match.

Fixes #110.