### PR TITLE
fix: Missing `pkg` variable

### DIFF
--- a/R/packages.R
+++ b/R/packages.R
@@ -11,7 +11,7 @@ resolve_dependencies <- function(pkgs, local = TRUE) {
   unique(inst$get_resolution()$package)
 }
 
-check_repo_pkg_version <- function(desc, ver) {
+check_repo_pkg_version <- function(desc, ver, pkg) {
   # Show a warning if packages major.minor versions differ
   # We don't worry too much about patch, since webR versions of packages may be
   # patched at the repo for compatibility with Emscripten
@@ -38,7 +38,7 @@ get_wasm_assets <- function(desc, repo) {
   }
 
   ver <- info[pkg, "Version", drop = TRUE]
-  check_repo_pkg_version(desc, ver)
+  check_repo_pkg_version(desc, ver, pkg)
 
   list(
     list(


### PR DESCRIPTION
Fixes error in shiny website build: 

```
Error in `lapply(text, glue_cmd, .envir = .envir)`:
! Could not evaluate cli `{}` expression: `pkg`.
Caused by error in `eval(expr, envir = envir)`:
! object 'pkg' not found
```

```
...
9. shinylive:::get_wasm_assets(desc, repo = "http://repo.r-wasm.org/")
10. shinylive:::check_repo_pkg_version(desc, ver)
11. cli::cli_warn(c("Package version mismatch for {.pkg {pkg}}, ensure the ver…
...
```