### PR TITLE
Avoid `LinkingTo` dependencies in package resolution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinylive (development version)
 
+* shinylive now avoids bundling WebAssembly R package dependencies listed only in the `LinkingTo` section of required packages. With this change dependencies that are only required at build time are no longer included as part of the exported WebAssembly asset bundle. This reduces the total static asset size and improves the loading time of affected shinylive apps. (#115)
+
 # shinylive 0.2.0
 
 * shinylive now uses [shinylive web assets v0.5.0](https://github.com/posit-dev/shinylive/releases/tag/v0.5.0) by default, which bundles webR 0.4.0 with R 4.4.1. This update brings improved keyboard shortcuts for R users in the Shinylive editor, the ability to export a custom library of R packages with the exported app, and a few improvements to the Quarto integration. (#108)

--- a/R/packages.R
+++ b/R/packages.R
@@ -6,7 +6,7 @@ sys_env_max_filesize <- function() {
   if (max_fs_env == "") NULL else max_fs_env
 }
 
-# Resolve package list hard dependencies
+# Resolve package list, dependencies listed in Depends and Imports
 resolve_dependencies <- function(pkgs, local = TRUE) {
   pkg_refs <- if (local) {
     refs <- find.package(pkgs, lib.loc = NULL, quiet = FALSE, !is_quiet())
@@ -14,7 +14,8 @@ resolve_dependencies <- function(pkgs, local = TRUE) {
   } else {
     pkgs
   }
-  inst <- pkgdepends::new_pkg_deps(pkg_refs)
+  wasm_config <- list(dependencies = c("Depends", "Imports"))
+  inst <- pkgdepends::new_pkg_deps(pkg_refs, config = wasm_config)
   inst$resolve()
   unique(inst$get_resolution()$package)
 }


### PR DESCRIPTION
Packages listed under `LinkingTo` are required for _building_ dependent packages, but not loading them at runtime.

So, we can ignore these R packages when we're looking for dependencies to bundle with a webR+shinylive app. In webR 0.4.1, these packages will also be ignored when invoking `webr::install()`, and I'm told the native `install.packages()` already does the same.

See https://github.com/quarto-ext/shinylive/issues/59 for discussion.

c.f. https://github.com/r-wasm/webr/pull/463