### PR TITLE
Add `SHINYLIVE_WASM_PACKAGES` environment variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinylive (development version)
 
+* In CI and other automated workflow settings the `SHINYLIVE_WASM_PACKAGES` environment variable can now be used to control whether WebAssembly R package binaries are bundled with the exported shinylive app, in addition to the `wasm_packages` argument of the `export()` function. (#116)
+
 # shinylive 0.2.0
 
 * shinylive now uses [shinylive web assets v0.5.0](https://github.com/posit-dev/shinylive/releases/tag/v0.5.0) by default, which bundles webR 0.4.0 with R 4.4.1. This update brings improved keyboard shortcuts for R users in the Shinylive editor, the ability to export a custom library of R packages with the exported app, and a few improvements to the Quarto integration. (#108)

--- a/R/export.R
+++ b/R/export.R
@@ -87,14 +87,7 @@ export <- function(
     assets_version <- assets_version()
   }
 
-  wasm_packages_val <- wasm_packages %||% sys_env_wasm_packages()
-  wasm_packages <- as.logical(wasm_packages_val)
-  if (is.na(wasm_packages)) {
-    cli::cli_abort(c(
-      "x" = "Could not parse `wasm_packages` value: {.code {wasm_packages_val}}"
-    ))
-    wasm_packages <- SHINYLIVE_WASM_PACKAGES
-  }
+  wasm_packages <- wasm_packages %||% sys_env_wasm_packages()
 
   if (!fs::is_dir(appdir)) {
     cli::cli_abort("{.var appdir} must be a directory, but was provided {.path {appdir}}.")

--- a/R/export.R
+++ b/R/export.R
@@ -10,8 +10,11 @@
 #'   `shinylive.quiet` option or defaults to `FALSE` in interactive sessions if
 #'   not set.
 #' @param verbose Deprecated, please use `quiet` instead.
-#' @param wasm_packages Download and include binary WebAssembly packages as
-#'   part of the output app's static assets. Defaults to `TRUE`.
+#' @param wasm_packages Download and include binary WebAssembly packages as part
+#'   of the output app's static assets. Logical, defaults to `TRUE`. The default
+#'   value can be changed by setting the environment variable
+#'   `SHINYLIVE_WASM_PACKAGES` to `TRUE` or `1` to enable, `FALSE` or `0` to
+#'   disable.
 #' @param package_cache Cache downloaded binary WebAssembly packages. Defaults
 #'   to `TRUE`.
 #' @param max_filesize Maximum file size for bundling of WebAssembly package
@@ -61,7 +64,7 @@ export <- function(
   ...,
   subdir = "",
   quiet = getOption("shinylive.quiet", !is_interactive()),
-  wasm_packages = TRUE,
+  wasm_packages = NULL,
   package_cache = TRUE,
   max_filesize = NULL,
   assets_version = NULL,
@@ -82,6 +85,15 @@ export <- function(
 
   if (is.null(assets_version)) {
     assets_version <- assets_version()
+  }
+
+  wasm_packages_val <- wasm_packages %||% sys_env_wasm_packages()
+  wasm_packages <- as.logical(wasm_packages_val)
+  if (is.na(wasm_packages)) {
+    cli::cli_abort(c(
+      "x" = "Could not parse `wasm_packages` value: {.code {wasm_packages_val}}"
+    ))
+    wasm_packages <- SHINYLIVE_WASM_PACKAGES
   }
 
   if (!fs::is_dir(appdir)) {

--- a/R/packages.R
+++ b/R/packages.R
@@ -1,4 +1,5 @@
 SHINYLIVE_DEFAULT_MAX_FILESIZE <- "100MB"
+SHINYLIVE_WASM_PACKAGES <- TRUE
 
 # Sys env maximum filesize for asset bundling
 sys_env_max_filesize <- function() {
@@ -6,7 +7,12 @@ sys_env_max_filesize <- function() {
   if (max_fs_env == "") NULL else max_fs_env
 }
 
-# Resolve package list hard dependencies
+sys_env_wasm_packages <- function() {
+  pkgs_env <- Sys.getenv("SHINYLIVE_WASM_PACKAGES", SHINYLIVE_WASM_PACKAGES)
+  switch(pkgs_env, "1" = TRUE, "0" = FALSE, pkgs_env)
+}
+
+# Resolve package list, dependencies listed in Depends and Imports
 resolve_dependencies <- function(pkgs, local = TRUE) {
   pkg_refs <- if (local) {
     refs <- find.package(pkgs, lib.loc = NULL, quiet = FALSE, !is_quiet())

--- a/R/packages.R
+++ b/R/packages.R
@@ -9,7 +9,12 @@ sys_env_max_filesize <- function() {
 
 sys_env_wasm_packages <- function() {
   pkgs_env <- Sys.getenv("SHINYLIVE_WASM_PACKAGES", SHINYLIVE_WASM_PACKAGES)
-  switch(pkgs_env, "1" = TRUE, "0" = FALSE, pkgs_env)
+  pkgs_env <- switch(pkgs_env, "1" = TRUE, "0" = FALSE, pkgs_env)
+  wasm_packages <- as.logical(pkgs_env)
+  if (is.na(wasm_packages)) {
+    cli::cli_abort("Could not parse `wasm_packages` value: {.code {pkgs_env}}")
+  }
+  wasm_packages
 }
 
 # Resolve package list, dependencies listed in Depends and Imports

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -253,11 +253,22 @@ build_app_resources <- function(app_json) {
     }
   })
 
-  # Download wasm binaries ready to embed into Quarto deps
-  withr::with_options(
-    list(shinylive.quiet = TRUE),
-    download_wasm_packages(appdir, destdir, package_cache = TRUE, max_filesize = NULL)
-  )
+  wasm_packages_val <- sys_env_wasm_packages()
+  wasm_packages <- as.logical(wasm_packages_val)
+  if (is.na(wasm_packages)) {
+    cli::cli_abort(c(
+      "x" = "Could not parse `wasm_packages` value: {.code {wasm_packages_val}}"
+    ))
+    wasm_packages <- SHINYLIVE_WASM_PACKAGES
+  }
+
+  if (wasm_packages) {
+    # Download wasm binaries ready to embed into Quarto deps
+    withr::with_options(
+      list(shinylive.quiet = TRUE),
+      download_wasm_packages(appdir, destdir, package_cache = TRUE, max_filesize = NULL)
+    )
+  }
 
   # Enumerate R package Wasm binaries and prepare the VFS images as html deps
   webr_dir <- fs::path(destdir, "shinylive", "webr")

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -253,15 +253,7 @@ build_app_resources <- function(app_json) {
     }
   })
 
-  wasm_packages_val <- sys_env_wasm_packages()
-  wasm_packages <- as.logical(wasm_packages_val)
-  if (is.na(wasm_packages)) {
-    cli::cli_abort(c(
-      "x" = "Could not parse `wasm_packages` value: {.code {wasm_packages_val}}"
-    ))
-    wasm_packages <- SHINYLIVE_WASM_PACKAGES
-  }
-
+  wasm_packages <- sys_env_wasm_packages()
   if (wasm_packages) {
     # Download wasm binaries ready to embed into Quarto deps
     withr::with_options(

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -10,7 +10,7 @@ export(
   ...,
   subdir = "",
   quiet = getOption("shinylive.quiet", !is_interactive()),
-  wasm_packages = TRUE,
+  wasm_packages = NULL,
   package_cache = TRUE,
   max_filesize = NULL,
   assets_version = NULL,
@@ -32,8 +32,11 @@ export(
 \code{shinylive.quiet} option or defaults to \code{FALSE} in interactive sessions if
 not set.}
 
-\item{wasm_packages}{Download and include binary WebAssembly packages as
-part of the output app's static assets. Defaults to \code{TRUE}.}
+\item{wasm_packages}{Download and include binary WebAssembly packages as part
+of the output app's static assets. Logical, defaults to \code{TRUE}. The default
+value can be changed by setting the environment variable
+\code{SHINYLIVE_WASM_PACKAGES} to \code{TRUE} or \code{1} to enable, \code{FALSE} or \code{0} to
+disable.}
 
 \item{package_cache}{Cache downloaded binary WebAssembly packages. Defaults
 to \code{TRUE}.}

--- a/tests/testthat/test-export.R
+++ b/tests/testthat/test-export.R
@@ -152,6 +152,16 @@ test_that("export - include R package in wasm assets", {
   app_dir <- test_path("apps", "app-utf8")
   asset_package <- c("utf8")
 
+  # No external dependencies exported
+  expect_silent_unattended({
+    withr::with_envvar(
+      list("SHINYLIVE_WASM_PACKAGES" = "FALSE"),
+      export(app_dir, out_dir)
+    )
+  })
+  expect_length(dir(pkg_dir), 0)
+  unlink_path(out_dir)
+
   # Default filesize 100MB
   expect_silent_unattended({
     export(app_dir, out_dir)


### PR DESCRIPTION
Continuing the work in https://github.com/posit-dev/r-shinylive/pull/114 and earlier PRs, adds an environment variable `SHINYLIVE_WASM_PACKAGES`, defaulting to `TRUE`.

When `SHINYLIVE_WASM_PACKAGES` is set to `FALSE` or `0`, no wasm R packages are exported at all. This allows the user to turn off the mechanism when using Shinylive with Quarto, should they want to.

Closes https://github.com/quarto-ext/shinylive/issues/60.