### PR TITLE
Fix: Allow `shinylive-r` chunks to create files in subdirectories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * shinylive now avoids bundling WebAssembly R package dependencies listed only in the `LinkingTo` section of required packages. With this change dependencies that are only required at build time are no longer included as part of the exported WebAssembly asset bundle. This reduces the total static asset size and improves the loading time of affected shinylive apps. (#115)
 
+* shinylive now supports adding files in virtual subdirectories in `shinylive-r` apps emebedded in Quarto documents. For example, `## file: R/load_data.R` in a `shinylive-r` chunk followed by the `load_data.R` code will create a file `load_data.R` in the `R` subdirectory of the exported app. (#119)
+
 # shinylive 0.2.0
 
 * shinylive now uses [shinylive web assets v0.5.0](https://github.com/posit-dev/shinylive/releases/tag/v0.5.0) by default, which bundles webR 0.4.0 with R 4.4.1. This update brings improved keyboard shortcuts for R users in the Shinylive editor, the ability to export a custom library of R packages with the exported app, and a few improvements to the Quarto integration. (#108)

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -242,7 +242,16 @@ build_app_resources <- function(app_json) {
     simplifyMatrix = FALSE
   )
   lapply(app, function(file) {
-    file_path <- fs::path(appdir, file$name)
+    file_name <- fs::path_norm(file$name)
+    
+    if (grepl("^(/|[.]{2})", file_name)) {
+      cli::cli_abort(c(
+        "App file paths must be relative to the app directory",
+        x = "Invalid file path: {.path {file$name}}"
+      ))
+    }
+
+    file_path <- fs::path(appdir, file_name)
     fs::dir_create(fs::path_dir(file_path))
     
     if (file$type == "text") {

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -243,6 +243,8 @@ build_app_resources <- function(app_json) {
   )
   lapply(app, function(file) {
     file_path <- fs::path(appdir, file$name)
+    fs::dir_create(fs::path_dir(file_path))
+    
     if (file$type == "text") {
       writeLines(file$content, file_path)
     } else {


### PR DESCRIPTION
This PR updates `build_app_resources()` so that it can create files in subdirectories, e.g.

```
## file: R/load_data.R
data <- read.csv("data.csv")
```

This would previously fail because `writeLines()` would write to `"{appdir}/R/load_data.R"` but `{appdir}/R` doesn't exist yet.

While here I also added a check, after normalizing `file$name`, to make sure that file names are specified relative to the app directory and don't escape upwards.