### PR TITLE
Update shinylive assets version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinylive (development version)
 
+* Updated default shinylive assets to [v0.6.0](https://github.com/posit-dev/shinylive/releases/tag/v0.6.0).
+
 * In CI and other automated workflow settings the `SHINYLIVE_WASM_PACKAGES` environment variable can now be used to control whether WebAssembly R package binaries are bundled with the exported shinylive app, in addition to the `wasm_packages` argument of the `export()` function. (#116)
 
 * shinylive now avoids bundling WebAssembly R package dependencies listed only in the `LinkingTo` section of required packages. With this change dependencies that are only required at build time are no longer included as part of the exported WebAssembly asset bundle. This reduces the total static asset size and improves the loading time of affected shinylive apps. (#115)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # shinylive (development version)
 
-* Updated default shinylive assets to [v0.6.0](https://github.com/posit-dev/shinylive/releases/tag/v0.6.0).
+* Updated default shinylive assets to [v0.6.0](https://github.com/posit-dev/shinylive/releases/tag/v0.6.0). (#120)
 
 * In CI and other automated workflow settings the `SHINYLIVE_WASM_PACKAGES` environment variable can now be used to control whether WebAssembly R package binaries are bundled with the exported shinylive app, in addition to the `wasm_packages` argument of the `export()` function. (#116)
 

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.5.0"
+SHINYLIVE_ASSETS_VERSION <- "0.6.0"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.4.1"


### PR DESCRIPTION
https://github.com/posit-dev/shinylive/releases/tag/v0.6.0

I'm thinking we should have the dev version of shinylive track the latest shinylive released assets version.

I've added a NEWS item so that it's clear we've updated the default, but that version number might change before a CRAN release, depending on when that happens next.