### PR TITLE
feat: Build resources relative to Quarto project root

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # shinylive (development version)
 
-* Updated default shinylive assets to [v0.6.0](https://github.com/posit-dev/shinylive/releases/tag/v0.6.0). (#120)
+* Updated default shinylive assets to [v0.7.0](https://github.com/posit-dev/shinylive/releases/tag/v0.7.0). (#120, #129)
+
+* Resources are now built relative to Quarto project root. (#130)
 
 * In CI and other automated workflow settings the `SHINYLIVE_WASM_PACKAGES` environment variable can now be used to control whether WebAssembly R package binaries are bundled with the exported shinylive app, in addition to the `wasm_packages` argument of the `export()` function. (#116)
 

--- a/R/quarto_ext.R
+++ b/R/quarto_ext.R
@@ -226,8 +226,9 @@ quarto_ext <- function(
 }
 
 build_app_resources <- function(app_json) {
-  appdir <- fs::path(".quarto", "_webr", "appdir")
-  destdir <- fs::path(".quarto", "_webr", "destdir")
+  projdir <- Sys.getenv("QUARTO_PROJECT_DIR", ".")
+  appdir <- fs::path(projdir, ".quarto", "_webr", "appdir")
+  destdir <- fs::path(projdir, ".quarto", "_webr", "destdir")
 
   # Build app directory, removing any previous app expanded there
   if (fs::dir_exists(appdir)) {


### PR DESCRIPTION
Avoids downloading the same R package(s) many times when using the shinylive extension in a Quarto project with multiple documents in subdirectories.

Fixes https://github.com/quarto-ext/shinylive/issues/61.

A fallback of `"."` (corresponding to the current behaviour) is set incase the `QUARTO_PROJECT_DIR` environment variable is ever unset.