### PR TITLE
build: Bump assets default version to 0.9.0

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.8.0"
+SHINYLIVE_ASSETS_VERSION <- "0.9.0"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.4.1"


### PR DESCRIPTION
Tested by exporting a single _hello world_ app locally. (Watched assets get downloaded and ran app)