### PR TITLE
Update shinylive assets to v0.10.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinylive (development version)
 
+* Updated default shinylive assets to [v0.10.5](https://github.com/posit-dev/shinylive/releases/tag/v0.10.5). (#165)
+
 # shinylive 0.3.0
 
 * Updated default shinylive assets to [v0.9.1](https://github.com/posit-dev/shinylive/releases/tag/v0.9.1). (#120, #129, #135)

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.9.1"
+SHINYLIVE_ASSETS_VERSION <- "0.10.5"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
-WEBR_R_VERSION <- "4.4.1"
+WEBR_R_VERSION <- "4.5.1"


### PR DESCRIPTION
Includes update to webR v0.5.5, which has support for [curl](https://jeroen.github.io/notes/webassembly-curl/).