### PR TITLE
chore: Bump SHINYLIVE_ASSETS_VERSION to 0.10.8

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.10.6"
+SHINYLIVE_ASSETS_VERSION <- "0.10.8"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.5.1"


### PR DESCRIPTION
## Summary

- Update `SHINYLIVE_ASSETS_VERSION` from `0.10.6` to `0.10.8`
- Includes py-shiny v1.6.0

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)