### PR TITLE
fix: Install jupyter in integration GHA job

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,10 +31,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Upgrade pip
+      - name: Upgrade pip and install Jupyter
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          python -m pip install jupyter
 
       - name: Install py-shinylive
         id: py-shinylive


### PR DESCRIPTION
## Summary

The `integration` job has been failing because Quarto's internal Jupyter support requires `pyyaml`, which was previously installed as a transitive dependency (via `pre-commit`) but is no longer pulled in. This adds an explicit `pip install jupyter` step so Quarto can discover and use the Python environment when rendering documents.

## Test plan

- [x] Verify the `integration` job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)