### PR TITLE
chore: Update SHINYLIVE_ASSETS_VERSION to 0.10.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinylive
 Title: Run 'shiny' Applications in the Browser
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R: c(
     person("Barret", "Schloerke", , "barret@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# shinylive 0.4.1.9000
+
+* Updated default shinylive assets to
+  [v0.10.9](https://github.com/posit-dev/shinylive/releases/tag/v0.10.9).
+
 # shinylive 0.4.1
 
 ## Bug fixes

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.10.8"
+SHINYLIVE_ASSETS_VERSION <- "0.10.9"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.5.1"


### PR DESCRIPTION
## Summary

* Update `SHINYLIVE_ASSETS_VERSION` from 0.10.8 to 0.10.9.

Part of the py-shiny v1.6.1 release train.