### PR TITLE
chore: Bump SHINYLIVE_ASSETS_VERSION to 0.10.10

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ Config/usethis/last-upkeep: 2026-03-30
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.10.9"
+SHINYLIVE_ASSETS_VERSION <- "0.10.10"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.5.1"

--- a/man/shinylive-package.Rd
+++ b/man/shinylive-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Barret Schloerke \email{barret@posit.co} (\href{https://orcid.org/0000-0001-9986-114X}{ORCID})
   \item Winston Chang \email{winston@posit.co} (\href{https://orcid.org/0000-0002-1576-2126}{ORCID})
   \item George Stagg \email{george.stagg@posit.co}
   \item Garrick Aden-Buie \email{garrick@posit.co} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID})


### PR DESCRIPTION
## Summary

Bump `SHINYLIVE_ASSETS_VERSION` in `R/version.R` from `0.10.9` → `0.10.10` to pick up the new shinylive web assets that ship with the py-shiny v1.6.2 release train.

See https://github.com/posit-dev/shinylive/releases/tag/v0.10.10