### PR TITLE
fix: Stale WASM package cache updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,8 @@ License: MIT + file LICENSE
 URL: https://posit-dev.github.io/r-shinylive/,
     https://github.com/posit-dev/r-shinylive
 BugReports: https://github.com/posit-dev/r-shinylive/issues
+Depends:
+    R (>= 4.0)
 Imports:
     archive,
     brio,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # shinylive 0.4.1.9000
 
+## Bug fixes
+
+* Fixed a stale WASM package cache where a package binary downloaded while the
+  WebAssembly repository lagged behind the locally installed version was never
+  replaced once the repository caught up.
+
 * Updated default shinylive assets to
   [v0.10.9](https://github.com/posit-dev/shinylive/releases/tag/v0.10.9).
 

--- a/R/packages.R
+++ b/R/packages.R
@@ -59,7 +59,14 @@ get_wasm_assets <- function(desc, repo) {
   r_short <- gsub("\\.[^.]+$", "", WEBR_R_VERSION)
   contrib <- glue::glue("{repo}/bin/emscripten/contrib/{r_short}")
 
-  info <- utils::available.packages(contriburl = contrib)
+  # Cache the repository index in a persistent per-user cache (default 1h TTL)
+  # so repeated lookups across renders avoid re-downloading the PACKAGES index.
+  fs::dir_create(tools::R_user_dir("base", "cache"))
+  info <- utils::available.packages(
+    contriburl = contrib,
+    cache_user_dir = TRUE
+  )
+
   if (!pkg %in% rownames(info)) {
     cli_alert_danger(
       "{.pkg {pkg_wrap(pkg)}} not available in Wasm binary repository: {.url {repo}}"
@@ -76,7 +83,8 @@ get_wasm_assets <- function(desc, repo) {
   list(
     list(
       filename = glue::glue("{pkg}_{ver}.tgz"),
-      url = glue::glue("{contrib}/{pkg}_{ver}.tgz")
+      url = glue::glue("{contrib}/{pkg}_{ver}.tgz"),
+      version = ver
     )
   )
 }
@@ -145,6 +153,17 @@ get_github_wasm_assets <- function(desc) {
   )
 }
 
+# Build the stored cache ref from the version actually resolved in the Wasm
+# binary repository (CRAN-like and Bioconductor are keyed purely by version).
+repo_ref <- function(desc, repo, ver) {
+  pkg <- desc$Package
+  if (grepl("Bioconductor", repo)) {
+    glue::glue("bioc::{pkg}@{ver}")
+  } else {
+    glue::glue("{pkg}@{ver}")
+  }
+}
+
 # Lookup URL and metadata for Wasm binary package
 prepare_wasm_metadata <- function(pkg, metadata) {
   desc <- utils::packageDescription(pkg)
@@ -165,44 +184,76 @@ prepare_wasm_metadata <- function(pkg, metadata) {
     return(metadata)
   }
 
-  # Set a package ref for caching
-  if (!is.null(desc$RemoteType) && desc$RemoteType == "github") {
+  # The "desired" ref is derived from the locally installed package; the ref
+  # we *store* reflects the version actually downloaded from the Wasm repo.
+  is_github <- !is.null(desc$RemoteType) && desc$RemoteType == "github"
+  is_runiverse <- !is_github &&
+    !is.null(repo) &&
+    grepl("r-universe\\.dev$", repo)
+  if (is_github) {
     user <- desc$RemoteUsername
     repo <- desc$RemoteRepo
     sha <- desc$RemoteSha
-    metadata$ref <- glue::glue("github::{user}/{repo}@{sha}")
+    desired_ref <- glue::glue("github::{user}/{repo}@{sha}")
   } else if (is.null(repo) || repo == "CRAN") {
     repo <- "CRAN"
-    metadata$ref <- glue::glue("{metadata$name}@{metadata$version}")
+    desired_ref <- glue::glue("{metadata$name}@{metadata$version}")
   } else if (grepl("Bioconductor", repo)) {
-    metadata$ref <- glue::glue("bioc::{metadata$name}@{metadata$version}")
-  } else if (grepl("r-universe\\.dev$", repo)) {
-    metadata$ref <- glue::glue("{repo}::{metadata$name}@{desc$RemoteSha}")
+    desired_ref <- glue::glue("bioc::{metadata$name}@{metadata$version}")
+  } else if (is_runiverse) {
+    desired_ref <- glue::glue("{repo}::{metadata$name}@{desc$RemoteSha}")
   } else {
-    metadata$ref <- glue::glue("{metadata$name}@{metadata$version}")
+    desired_ref <- glue::glue("{metadata$name}@{metadata$version}")
   }
 
-  # If not cached, discover Wasm binary URLs
-  if (is.null(prev_cached) || !prev_cached || prev_ref != metadata$ref) {
+  # Cache is valid only if it was previously cached against the same desired ref.
+  # A missing/NA stored ref is treated as a miss so we retry.
+  cache_valid <- !is.null(prev_cached) &&
+    prev_cached &&
+    !is.null(prev_ref) &&
+    !is.na(prev_ref) &&
+    prev_ref == desired_ref
+
+  if (!cache_valid) {
+    # Cache miss: discover Wasm binary URLs and reconcile on-disk binaries
     metadata$cached <- FALSE
-    if (!is.null(desc$RemoteType) && desc$RemoteType == "github") {
+    if (is_github) {
       metadata$assets <- get_github_wasm_assets(desc)
       metadata$type <- "library"
-    } else if (grepl("r-universe\\.dev$", repo)) {
-      metadata$assets <- get_wasm_assets(desc, repo = desc$Repository)
-      metadata$type <- "package"
-    } else if (grepl("Bioconductor", repo)) {
-      # Use r-universe for Bioconductor packages
-      metadata$assets <- get_wasm_assets(
-        desc,
-        repo = "https://bioc.r-universe.dev"
-      )
-      metadata$type <- "package"
+      metadata$ref <- desired_ref
     } else {
-      # Fallback to repo.r-wasm.org lookup for CRAN and anything else
-      metadata$assets <- get_wasm_assets(desc, repo = "https://repo.r-wasm.org")
+      if (is_runiverse) {
+        metadata$assets <- get_wasm_assets(desc, repo = desc$Repository)
+      } else if (grepl("Bioconductor", repo)) {
+        # Use r-universe for Bioconductor packages
+        metadata$assets <- get_wasm_assets(
+          desc,
+          repo = "https://bioc.r-universe.dev"
+        )
+      } else {
+        # Fallback to repo.r-wasm.org lookup for CRAN and anything else
+        metadata$assets <- get_wasm_assets(
+          desc,
+          repo = "https://repo.r-wasm.org"
+        )
+      }
       metadata$type <- "package"
+
+      # Store the ref of the version actually resolved in the repo, so the cache
+      # self-invalidates once the repo catches up to the desired local version.
+      if (length(metadata$assets) > 0 && !is.null(metadata$assets[[1]]$version)) {
+        metadata$ref <- if (is_runiverse) {
+          desired_ref
+        } else {
+          repo_ref(desc, repo, metadata$assets[[1]]$version)
+        }
+      } else {
+        metadata$ref <- NA_character_
+      }
     }
+  } else {
+    # Cache hit: keep the downloaded version.
+    metadata$ref <- prev_ref
   }
 
   metadata
@@ -331,10 +382,25 @@ download_wasm_packages <- function(
     meta <- prepare_wasm_metadata(pkg, prev_meta)
 
     if (!meta$cached) {
+      wanted <- vapply(meta$assets, function(asset) asset$filename, character(1))
+
+      # Remove stale binaries no longer wanted (e.g. an old package version).
+      if (length(meta$assets) > 0 && fs::dir_exists(pkg_subdir)) {
+        existing <- fs::dir_ls(pkg_subdir, type = "file")
+        stale <- existing[!(fs::path_file(existing) %in% wanted)]
+        if (length(stale) > 0) {
+          fs::file_delete(stale)
+        }
+      }
+
       # Download Wasm binaries and copy to static assets dir
       for (file in meta$assets) {
         path <- fs::path(pkg_subdir, file$filename)
-        utils::download.file(file$url, path, mode = "wb", quiet = TRUE)
+
+        # Skip the download if we already have this exact binary.
+        if (!fs::file_exists(path)) {
+          utils::download.file(file$url, path, mode = "wb", quiet = TRUE)
+        }
 
         # Disallow this package if an asset is too large
         if (fs::file_size(path) > max_filesize) {

--- a/R/packages.R
+++ b/R/packages.R
@@ -61,6 +61,7 @@ get_wasm_assets <- function(desc, repo) {
 
   # Cache the repository index in a persistent per-user cache (default 1h TTL)
   # so repeated lookups across renders avoid re-downloading the PACKAGES index.
+  # Required: available.packages(cache_user_dir = TRUE) errors if this dir is absent.
   fs::dir_create(tools::R_user_dir("base", "cache"))
   info <- utils::available.packages(
     contriburl = contrib,

--- a/R/packages.R
+++ b/R/packages.R
@@ -241,7 +241,9 @@ prepare_wasm_metadata <- function(pkg, metadata) {
 
       # Store the ref of the version actually resolved in the repo, so the cache
       # self-invalidates once the repo catches up to the desired local version.
-      if (length(metadata$assets) > 0 && !is.null(metadata$assets[[1]]$version)) {
+      if (
+        length(metadata$assets) > 0 && !is.null(metadata$assets[[1]]$version)
+      ) {
         metadata$ref <- if (is_runiverse) {
           desired_ref
         } else {
@@ -382,7 +384,11 @@ download_wasm_packages <- function(
     meta <- prepare_wasm_metadata(pkg, prev_meta)
 
     if (!meta$cached) {
-      wanted <- vapply(meta$assets, function(asset) asset$filename, character(1))
+      wanted <- vapply(
+        meta$assets,
+        function(asset) asset$filename,
+        character(1)
+      )
 
       # Remove stale binaries no longer wanted (e.g. an old package version).
       if (length(meta$assets) > 0 && fs::dir_exists(pkg_subdir)) {

--- a/R/packages.R
+++ b/R/packages.R
@@ -61,11 +61,15 @@ get_wasm_assets <- function(desc, repo) {
 
   # Cache the repository index in a persistent per-user cache (default 1h TTL)
   # so repeated lookups across renders avoid re-downloading the PACKAGES index.
-  # Required: available.packages(cache_user_dir = TRUE) errors if this dir is absent.
-  fs::dir_create(tools::R_user_dir("base", "cache"))
+  # Skipped under CRAN testing so we never write to the user cache dir (#186).
+  cache_user_dir <- !cran_is_testing()
+  if (cache_user_dir) {
+    # Required: available.packages(cache_user_dir = TRUE) errors if dir is absent.
+    fs::dir_create(tools::R_user_dir("base", "cache"))
+  }
   info <- utils::available.packages(
     contriburl = contrib,
-    cache_user_dir = TRUE
+    cache_user_dir = cache_user_dir
   )
 
   if (!pkg %in% rownames(info)) {

--- a/tests/testthat/test-packages.R
+++ b/tests/testthat/test-packages.R
@@ -86,6 +86,32 @@ test_that("stable cache hit when stored ref equals desired ref", {
   expect_equal(as.character(m$ref), "scales@1.4.0")
 })
 
+test_that("a patch-level repo/local version mismatch never reaches a stable cache hit", {
+  skip_on_cran()
+  local_mocked_bindings(
+    packageDescription = function(...) cran_desc("1.4.0"),
+    .package = "utils"
+  )
+  # The repo serves a build whose version string differs only in patch from the
+  # locally installed version (webR may patch packages at the repo). The stored
+  # ref keys on the repo version, while the desired ref keys on the local one.
+  local_mocked_bindings(
+    get_wasm_assets = function(desc, repo) wasm_asset("scales", "1.4.0-1")
+  )
+
+  # First pass: miss, stores the repo's (patched) version as the ref.
+  m1 <- prepare_wasm_metadata("scales", list())
+  expect_false(m1$cached)
+  expect_equal(as.character(m1$ref), "scales@1.4.0-1")
+
+  # Next render: desired (local 1.4.0) still != stored (repo 1.4.0-1), so the
+  # cache never stabilises to a hit even though the repo has not changed.
+  m1$cached <- TRUE
+  m2 <- prepare_wasm_metadata("scales", m1)
+  expect_false(m2$cached)
+  expect_equal(as.character(m2$ref), "scales@1.4.0-1")
+})
+
 test_that("package missing from the repo gets an NA ref and retries", {
   skip_on_cran()
   local_mocked_bindings(

--- a/tests/testthat/test-packages.R
+++ b/tests/testthat/test-packages.R
@@ -1,0 +1,188 @@
+# Tests for Wasm package cache invalidation logic in R/packages.R.
+#
+# These exercise the cache-key handling that keeps a package's downloaded Wasm
+# binary in sync with the version actually served by the Wasm binary repository
+# (which can lag behind the locally installed version).
+
+cran_desc <- function(version = "1.4.0") {
+  list(Package = "scales", Version = version, Repository = "CRAN")
+}
+
+wasm_asset <- function(pkg = "scales", version = "1.4.0") {
+  list(list(
+    filename = glue::glue("{pkg}_{version}.tgz"),
+    url = glue::glue("https://repo.r-wasm.org/.../{pkg}_{version}.tgz"),
+    version = version
+  ))
+}
+
+test_that("repo lag stores the downloaded version and keeps re-checking", {
+  skip_on_cran()
+  local_mocked_bindings(
+    packageDescription = function(...) cran_desc("1.4.0"),
+    .package = "utils"
+  )
+  # Repository lags behind local: it only serves scales 1.3.0
+  local_mocked_bindings(
+    get_wasm_assets = function(desc, repo) wasm_asset("scales", "1.3.0")
+  )
+
+  # First pass: no prior cache -> miss, stores the DOWNLOADED version as the ref
+  m1 <- prepare_wasm_metadata("scales", list())
+  expect_false(m1$cached)
+  expect_equal(as.character(m1$ref), "scales@1.3.0")
+
+  # The download loop would mark it cached; simulate the next render
+  m1$cached <- TRUE
+  m2 <- prepare_wasm_metadata("scales", m1)
+  # desired (1.4.0) != stored (1.3.0) -> still a miss, repo still lagging
+  expect_false(m2$cached)
+  expect_equal(as.character(m2$ref), "scales@1.3.0")
+})
+
+test_that("cache self-heals once the repo catches up", {
+  skip_on_cran()
+  local_mocked_bindings(
+    packageDescription = function(...) cran_desc("1.4.0"),
+    .package = "utils"
+  )
+  # Repo now serves the desired version
+  local_mocked_bindings(
+    get_wasm_assets = function(desc, repo) wasm_asset("scales", "1.4.0")
+  )
+
+  prior <- list(
+    name = "scales", version = "1.4.0", ref = "scales@1.3.0",
+    cached = TRUE, type = "package"
+  )
+  m <- prepare_wasm_metadata("scales", prior)
+  expect_false(m$cached) # re-download triggered
+  expect_equal(as.character(m$ref), "scales@1.4.0")
+})
+
+test_that("stable cache hit when stored ref equals desired ref", {
+  skip_on_cran()
+  local_mocked_bindings(
+    packageDescription = function(...) cran_desc("1.4.0"),
+    .package = "utils"
+  )
+  # Must not hit the network on a cache hit
+  local_mocked_bindings(
+    get_wasm_assets = function(desc, repo) stop("should not re-download")
+  )
+
+  prior <- list(
+    name = "scales", version = "1.4.0", ref = "scales@1.4.0",
+    cached = TRUE, type = "package"
+  )
+  m <- prepare_wasm_metadata("scales", prior)
+  expect_true(m$cached)
+  expect_equal(as.character(m$ref), "scales@1.4.0")
+})
+
+test_that("package missing from the repo gets an NA ref and retries", {
+  skip_on_cran()
+  local_mocked_bindings(
+    packageDescription = function(...) {
+      list(Package = "ghost", Version = "1.0.0", Repository = "CRAN")
+    },
+    .package = "utils"
+  )
+  local_mocked_bindings(get_wasm_assets = function(desc, repo) list())
+
+  m1 <- prepare_wasm_metadata("ghost", list())
+  expect_length(m1$assets, 0)
+  expect_true(is.na(m1$ref))
+
+  # Next render: an NA stored ref must be treated as a miss (retry)
+  m1$cached <- TRUE
+  m2 <- prepare_wasm_metadata("ghost", m1)
+  expect_false(m2$cached)
+})
+
+# Helpers for the download_wasm_packages() integration tests below.
+
+seed_packages_dir <- function(destdir, stale_file, ref) {
+  pkg_subdir <- fs::path(destdir, "shinylive", "webr", "packages", "scales")
+  fs::dir_create(pkg_subdir, recurse = TRUE)
+  fs::file_create(fs::path(pkg_subdir, stale_file))
+
+  meta_file <- fs::path(
+    destdir, "shinylive", "webr", "packages", "metadata.rds"
+  )
+  saveRDS(
+    list(scales = list(
+      name = "scales", version = "1.4.0", ref = ref,
+      cached = TRUE, type = "package",
+      path = glue::glue("packages/scales/{stale_file}")
+    )),
+    meta_file
+  )
+  pkg_subdir
+}
+
+mock_download_env <- function(repo_version, downloaded) {
+  local_mocked_bindings(
+    packageDescription = function(...) cran_desc("1.4.0"),
+    download.file = function(url, destfile, ...) {
+      downloaded$called <- TRUE
+      fs::file_create(destfile)
+      invisible(0)
+    },
+    .package = "utils",
+    .env = parent.frame()
+  )
+  local_mocked_bindings(
+    dependencies = function(...) data.frame(Package = "scales"),
+    .package = "renv",
+    .env = parent.frame()
+  )
+  local_mocked_bindings(
+    get_wasm_assets = function(desc, repo) {
+      downloaded$queried <- TRUE
+      wasm_asset("scales", repo_version)
+    },
+    resolve_dependencies = function(pkgs, local = TRUE) pkgs,
+    .env = parent.frame()
+  )
+}
+
+test_that("stale .tgz binaries are removed when the repo version changes", {
+  skip_on_cran()
+  withr::local_options(shinylive.quiet = TRUE)
+  out <- withr::local_tempdir()
+  pkg_subdir <- seed_packages_dir(out, "scales_1.3.0.tgz", "scales@1.3.0")
+
+  downloaded <- new.env()
+  mock_download_env(repo_version = "1.4.0", downloaded = downloaded)
+
+  suppressMessages(download_wasm_packages(
+    appdir = out, destdir = out, package_cache = TRUE, max_filesize = "100MB"
+  ))
+
+  files <- fs::path_file(fs::dir_ls(pkg_subdir, type = "file"))
+  expect_false("scales_1.3.0.tgz" %in% files)
+  expect_true("scales_1.4.0.tgz" %in% files)
+  expect_true(isTRUE(downloaded$called))
+})
+
+test_that("matching binary is not re-downloaded while the repo lags", {
+  skip_on_cran()
+  withr::local_options(shinylive.quiet = TRUE)
+  out <- withr::local_tempdir()
+  pkg_subdir <- seed_packages_dir(out, "scales_1.3.0.tgz", "scales@1.3.0")
+
+  downloaded <- new.env()
+  # Repo still only serves 1.3.0, which is already on disk
+  mock_download_env(repo_version = "1.3.0", downloaded = downloaded)
+
+  suppressMessages(download_wasm_packages(
+    appdir = out, destdir = out, package_cache = TRUE, max_filesize = "100MB"
+  ))
+
+  files <- fs::path_file(fs::dir_ls(pkg_subdir, type = "file"))
+  expect_true("scales_1.3.0.tgz" %in% files)
+  # The cheap repo re-query happened, but the binary was not re-downloaded
+  expect_true(isTRUE(downloaded$queried))
+  expect_false(isTRUE(downloaded$called))
+})

--- a/tests/testthat/test-packages.R
+++ b/tests/testthat/test-packages.R
@@ -52,8 +52,11 @@ test_that("cache self-heals once the repo catches up", {
   )
 
   prior <- list(
-    name = "scales", version = "1.4.0", ref = "scales@1.3.0",
-    cached = TRUE, type = "package"
+    name = "scales",
+    version = "1.4.0",
+    ref = "scales@1.3.0",
+    cached = TRUE,
+    type = "package"
   )
   m <- prepare_wasm_metadata("scales", prior)
   expect_false(m$cached) # re-download triggered
@@ -72,8 +75,11 @@ test_that("stable cache hit when stored ref equals desired ref", {
   )
 
   prior <- list(
-    name = "scales", version = "1.4.0", ref = "scales@1.4.0",
-    cached = TRUE, type = "package"
+    name = "scales",
+    version = "1.4.0",
+    ref = "scales@1.4.0",
+    cached = TRUE,
+    type = "package"
   )
   m <- prepare_wasm_metadata("scales", prior)
   expect_true(m$cached)
@@ -108,14 +114,23 @@ seed_packages_dir <- function(destdir, stale_file, ref) {
   fs::file_create(fs::path(pkg_subdir, stale_file))
 
   meta_file <- fs::path(
-    destdir, "shinylive", "webr", "packages", "metadata.rds"
+    destdir,
+    "shinylive",
+    "webr",
+    "packages",
+    "metadata.rds"
   )
   saveRDS(
-    list(scales = list(
-      name = "scales", version = "1.4.0", ref = ref,
-      cached = TRUE, type = "package",
-      path = glue::glue("packages/scales/{stale_file}")
-    )),
+    list(
+      scales = list(
+        name = "scales",
+        version = "1.4.0",
+        ref = ref,
+        cached = TRUE,
+        type = "package",
+        path = glue::glue("packages/scales/{stale_file}")
+      )
+    ),
     meta_file
   )
   pkg_subdir
@@ -157,7 +172,10 @@ test_that("stale .tgz binaries are removed when the repo version changes", {
   mock_download_env(repo_version = "1.4.0", downloaded = downloaded)
 
   suppressMessages(download_wasm_packages(
-    appdir = out, destdir = out, package_cache = TRUE, max_filesize = "100MB"
+    appdir = out,
+    destdir = out,
+    package_cache = TRUE,
+    max_filesize = "100MB"
   ))
 
   files <- fs::path_file(fs::dir_ls(pkg_subdir, type = "file"))
@@ -177,7 +195,10 @@ test_that("matching binary is not re-downloaded while the repo lags", {
   mock_download_env(repo_version = "1.3.0", downloaded = downloaded)
 
   suppressMessages(download_wasm_packages(
-    appdir = out, destdir = out, package_cache = TRUE, max_filesize = "100MB"
+    appdir = out,
+    destdir = out,
+    package_cache = TRUE,
+    max_filesize = "100MB"
   ))
 
   files <- fs::path_file(fs::dir_ls(pkg_subdir, type = "file"))


### PR DESCRIPTION
The WASM package cache can serve an outdated package binary indefinitely, causing apps to fail in the browser with errors like

```
preload error: namespace 'scales' 1.3.0 is being loaded, but >= 1.4.0 is required
```

even though repo.r-wasm.org now serves a later version.

The cache keys the re-download decision on the locally installed package version, but the binary actually downloaded is whatever version repo.r-wasm.org currently serves, which can lag behind CRAN. So if the repo lags at download time (local scales 1.4.0, repo only has 1.3.0), it stores `ref = scales@1.4.0` while the file on disk is `scales_1.3.0.tgz`. Once the repo catches up to 1.4.0, the recomputed ref still matches the stored ref, so it's a cache hit and the stale 1.3.0 binary is never replaced. The only workaround is manually deleting the cache directories and re-rendering.

The fix is to key the cache on the version actually downloaded from the repo so it self-invalidates and re-downloads once the repo catches up, remove stale `.tgz` files on re-download, skip re-downloading binaries already on disk, and cache the `available.packages()` index to keep the repeated repo lookups cheap.