### PR TITLE
Update default shinylive assets to v0.10.12

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # shinylive 0.4.1.9000
 
 * Updated default shinylive assets to
-  [v0.10.9](https://github.com/posit-dev/shinylive/releases/tag/v0.10.9).
+  [v0.10.12](https://github.com/posit-dev/shinylive/releases/tag/v0.10.12).
 
 # shinylive 0.4.1
 

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.10.11"
+SHINYLIVE_ASSETS_VERSION <- "0.10.12"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.6.0"


### PR DESCRIPTION
Bumps `SHINYLIVE_ASSETS_VERSION` to v0.10.12 (ships py-shiny 1.6.3).

Part of the py-shiny v1.6.3 release train. See posit-dev/py-shiny#2266.