### PR TITLE
Release shinylive 0.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinylive
 Title: Run 'shiny' Applications in the Browser
-Version: 0.4.1.9000
+Version: 0.4.2
 Authors@R: c(
     person("Barret", "Schloerke", , "barret@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# shinylive 0.4.1.9000
+# shinylive 0.4.2
 
 ## Bug fixes
 


### PR DESCRIPTION
Prep for the shinylive 0.4.2 CRAN release.

Working through the release checklist in #196.

- Bump version to 0.4.2
- (further release prep commits to follow)