### PR TITLE
v0.5.0 release candidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinylive
 Title: Run 'shiny' Applications in the Browser
-Version: 0.4.1.9000
+Version: 0.5.0
 Authors@R: c(
     person("Barret", "Schloerke", , "barret@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,16 @@
 # shinylive 0.5.0
 
-## Bug fixes
+## Bug fixes and minor improvements
 
-* Fixed a stale WASM package cache where a package binary downloaded while the
-  WebAssembly repository lagged behind the locally installed version was never
-  replaced once the repository caught up.
+* Updated the default shinylive assets to
+  [v0.10.12](https://github.com/posit-dev/shinylive/releases/tag/v0.10.12),
+  which upgrades the bundled webR to
+  [v0.6.0](https://github.com/r-wasm/webr/releases/tag/v0.6.0) (#193, #195).
 
-* Updated default shinylive assets to
-  [v0.10.12](https://github.com/posit-dev/shinylive/releases/tag/v0.10.12).
+* WebAssembly package binaries cached during `export()` are now replaced once
+  the WebAssembly repository catches up to the locally installed version.
+  Previously, a binary downloaded while the repository lagged behind was never
+  refreshed (#194).
 
 # shinylive 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# shinylive 0.4.1.9000
+# shinylive 0.5.0
 
 ## Bug fixes
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,56 +1,6 @@
-## Comments
-
-#### 2026-04-06
-
-CRAN package shinylive
-
-This violates the CRAN policy by leaving ca 737MB in ~/.cache/shinylive,
-a location that is not even allowed to be used.
-
-(~/Library/Caches/shinylive on macOS)
-
-It will be removed from CRAN. Then we will have to go round sweeping up
-after you on several machines ....
-
-- Brian D. Ripley
-
-
-#### 2026-04-06
-
-Sorry for the required cleanup. I had a test slip through the cracks.
-
-Changes made to address the cache folder being created during testing (https://github.com/posit-dev/r-shinylive/pull/186):
-* Added a runtime guard in `assets_cache_dir()` to error during CRAN testing, preventing any future cache directory creation on CRAN.
-* Tests that interact with the shinylive assets cache directory are now skipped on CRAN.
-
-Please let me know if I can provide any more information.
-
-Thank you for your time,
-Barret
-
-
-
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-```
-─  checking CRAN incoming feasibility ... [3s/17s] NOTE (16.7s)
-   Maintainer: ‘Barret Schloerke <barret@posit.co>’
-
-   New submission
-
-   Package was archived on CRAN
-
-   Version contains large components (0.4.0.9000)
-
-   CRAN repository db overrides:
-     X-CRAN-Comment: Archived on 2026-04-06 for policy violation.
-
-     Use of ~/.cache/shinylive, leaving 700+MB behind.
-```
-
-
+0 errors | 0 warnings | 0 notes
 
 ## Reverse dependencies
 

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -3,63 +3,60 @@
 |field    |value                          |
 |:--------|:------------------------------|
 |version  |R version 4.5.2 (2025-10-31)   |
-|os       |macOS Tahoe 26.3.1             |
+|os       |macOS Tahoe 26.5               |
 |system   |aarch64, darwin20              |
 |ui       |X11                            |
 |language |(EN)                           |
 |collate  |en_US.UTF-8                    |
 |ctype    |en_US.UTF-8                    |
 |tz       |America/New_York               |
-|date     |2026-03-31                     |
+|date     |2026-06-08                     |
 |pandoc   |3.9 @ /opt/homebrew/bin/pandoc |
 |quarto   |1.8.25 @ /usr/local/bin/quarto |
 
 # Dependencies
 
-|package     |old      |new      |Δ  |
-|:-----------|:--------|:--------|:--|
-|shinylive   |0.3.0    |0.4.0    |*  |
-|archive     |1.1.12.1 |1.1.12.1 |   |
-|askpass     |1.2.1    |1.2.1    |   |
-|brio        |1.1.5    |1.1.5    |   |
-|callr       |3.7.6    |3.7.6    |   |
-|cli         |3.6.5    |3.6.5    |   |
-|crayon      |1.5.3    |NA       |*  |
-|curl        |7.0.0    |7.0.0    |   |
-|desc        |1.4.3    |1.4.3    |   |
-|filelock    |1.0.3    |1.0.3    |   |
-|fs          |2.0.1    |2.0.1    |   |
-|gh          |1.5.0    |1.5.0    |   |
-|gitcreds    |0.1.2    |0.1.2    |   |
-|glue        |1.8.0    |1.8.0    |   |
-|hms         |1.1.4    |NA       |*  |
-|httr2       |1.2.2    |1.2.2    |   |
-|ini         |0.3.1    |0.3.1    |   |
-|jsonlite    |2.0.0    |2.0.0    |   |
-|lifecycle   |1.0.5    |1.0.5    |   |
-|lpSolve     |5.6.23   |5.6.23   |   |
-|magrittr    |2.0.4    |2.0.4    |   |
-|openssl     |2.3.5    |2.3.5    |   |
-|pillar      |1.11.1   |1.11.1   |   |
-|pkgbuild    |1.4.8    |1.4.8    |   |
-|pkgcache    |2.2.4    |2.2.4    |   |
-|pkgconfig   |2.0.3    |2.0.3    |   |
-|pkgdepends  |0.9.0    |0.9.0    |   |
-|prettyunits |1.2.0    |NA       |*  |
-|processx    |3.8.6    |3.8.6    |   |
-|progress    |1.2.3    |NA       |*  |
-|ps          |1.9.1    |1.9.1    |   |
-|R6          |2.6.1    |2.6.1    |   |
-|rappdirs    |0.3.4    |0.3.4    |   |
-|renv        |1.2.0    |1.2.0    |   |
-|rlang       |1.1.7    |1.1.7    |   |
-|sys         |3.4.3    |3.4.3    |   |
-|tibble      |3.3.1    |3.3.1    |   |
-|utf8        |1.2.6    |1.2.6    |   |
-|vctrs       |0.7.2    |0.7.2    |   |
-|whisker     |0.4.1    |0.4.1    |   |
-|withr       |3.0.2    |3.0.2    |   |
-|zip         |2.3.3    |2.3.3    |   |
+|package    |old    |new    |Δ  |
+|:----------|:------|:------|:--|
+|shinylive  |0.4.1  |0.5.0  |*  |
+|archive    |1.1.13 |1.1.13 |   |
+|askpass    |1.2.1  |1.2.1  |   |
+|brio       |1.1.5  |1.1.5  |   |
+|callr      |3.8.0  |3.8.0  |   |
+|cli        |3.6.6  |3.6.6  |   |
+|curl       |7.1.0  |7.1.0  |   |
+|desc       |1.4.3  |1.4.3  |   |
+|filelock   |1.0.3  |1.0.3  |   |
+|fs         |2.1.0  |2.1.0  |   |
+|gh         |1.6.0  |1.6.0  |   |
+|gitcreds   |0.1.2  |0.1.2  |   |
+|glue       |1.8.1  |1.8.1  |   |
+|httr2      |1.2.2  |1.2.2  |   |
+|ini        |0.3.1  |0.3.1  |   |
+|jsonlite   |2.0.0  |2.0.0  |   |
+|lifecycle  |1.0.5  |1.0.5  |   |
+|lpSolve    |5.6.23 |5.6.23 |   |
+|magrittr   |2.0.5  |2.0.5  |   |
+|openssl    |2.4.1  |2.4.1  |   |
+|otel       |0.2.0  |0.2.0  |   |
+|pillar     |1.11.1 |1.11.1 |   |
+|pkgbuild   |1.4.8  |1.4.8  |   |
+|pkgcache   |2.2.5  |2.2.5  |   |
+|pkgconfig  |2.0.3  |2.0.3  |   |
+|pkgdepends |0.9.1  |0.9.1  |   |
+|processx   |3.9.0  |3.9.0  |   |
+|ps         |1.9.3  |1.9.3  |   |
+|R6         |2.6.1  |2.6.1  |   |
+|rappdirs   |0.3.4  |0.3.4  |   |
+|renv       |1.2.3  |1.2.3  |   |
+|rlang      |1.2.0  |1.2.0  |   |
+|sys        |3.4.3  |3.4.3  |   |
+|tibble     |3.3.1  |3.3.1  |   |
+|utf8       |1.2.6  |1.2.6  |   |
+|vctrs      |0.7.3  |0.7.3  |   |
+|whisker    |0.4.1  |0.4.1  |   |
+|withr      |3.0.2  |3.0.2  |   |
+|zip        |2.3.3  |2.3.3  |   |
 
 # Revdeps
 


### PR DESCRIPTION
Release candidate for shinylive 0.5.0 (now accepted on CRAN 🎉).

Closes #198.

## Changes

* Bump version to 0.5.0 (`usethis::use_version('minor')`).
* Polish `NEWS.md` for the 0.5.0 release.
* Refresh `cran-comments.md` for a routine update (no reverse dependencies).
* Update `revdep/README.md` results for 0.5.0.

## NEWS

### Bug fixes and minor improvements

* Updated the default shinylive assets to v0.10.12, which upgrades the bundled
  webR to v0.6.0 (#193, #195).
* WebAssembly package binaries cached during `export()` are now replaced once
  the WebAssembly repository catches up to the locally installed version (#194).
