### PR TITLE
chore: Update default shinylive assets to v0.10.14

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # shinylive (development version)
 
+## Bug fixes and minor improvements
+
+* Updated the default shinylive assets to
+  [v0.10.14](https://github.com/posit-dev/shinylive/releases/tag/v0.10.14),
+  which bundles Shiny for Python
+  [v1.7.0](https://github.com/posit-dev/py-shiny/releases/tag/v1.7.0). The
+  bundled webR is unchanged at
+  [v0.6.0](https://github.com/r-wasm/webr/releases/tag/v0.6.0).
+
 # shinylive 0.5.0
 
 ## Bug fixes and minor improvements

--- a/R/packages.R
+++ b/R/packages.R
@@ -416,7 +416,7 @@ download_wasm_packages <- function(
         # Disallow this package if an asset is too large
         if (fs::file_size(path) > max_filesize) {
           fs::dir_delete(pkg_subdir)
-          meta$assets = list()
+          meta$assets <- list()
           max_filesize_cli_fn(c(
             "!" = "The file size of package {.pkg {pkg}} is larger than the maximum allowed file size of {.strong {max_filesize}}.",
             "!" = "This package will not be included as part of the WebAssembly asset bundle.",

--- a/R/version.R
+++ b/R/version.R
@@ -1,4 +1,4 @@
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION <- "0.10.12"
+SHINYLIVE_ASSETS_VERSION <- "0.10.14"
 SHINYLIVE_R_VERSION <- as.character(utils::packageVersion("shinylive"))
 WEBR_R_VERSION <- "4.6.0"


### PR DESCRIPTION
## What

- `R/version.R`: `SHINYLIVE_ASSETS_VERSION` `0.10.12` → **`0.10.14`**
- `NEWS.md`: entry under the development-version heading

[shinylive v0.10.14](https://github.com/posit-dev/shinylive/releases/tag/v0.10.14) bundles [Shiny for Python v1.7.0](https://github.com/posit-dev/py-shiny/releases/tag/v1.7.0) and shinyswatch 0.12.0. The bundled webR is unchanged at v0.6.0, so this is a Python-side asset refresh from R's perspective.

## Notes

- This skips **v0.10.13**, which was cut for the py-shiny 1.6.4 patch but [intentionally not redeployed](https://github.com/posit-dev/shinylive/releases/tag/v0.10.13) to shinylive.io. v0.10.14 is the first bundle since 0.10.12 that is live on both surfaces.
- `DESCRIPTION` is left alone: `Version` is already `0.5.0.9000`, a development version, so there is no dev bump to make. The NEWS entry goes under the existing `# shinylive (development version)` heading.
- No open PRs were touching `SHINYLIVE_ASSETS_VERSION` (#92 and #71 are both about lzstring URL encoding), so nothing needed closing first.

Part of the py-shiny v1.7.0 release train; see posit-dev/py-shiny#2377.